### PR TITLE
[FEAT] Appointment > 월별 시간표 탭 > 캘린더 섹션 뷰 작업 #15

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,11 +4,18 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>트다: 트레이닝 다이어리</title>
-    <link href="https://hangeul.pstatic.net/hangeul_static/css/nanum-square.css" rel="stylesheet" />
+    <link
+      href="https://hangeul.pstatic.net/hangeul_static/css/nanum-square.css"
+      rel="stylesheet"
+    />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
       href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@100..900&display=swap"
+      rel="stylesheet"
+    />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Roboto:ital,wght@0,100;0,300;0,400;0,500;0,700;0,900;1,100;1,300;1,400;1,500;1,700;1,900&display=swap"
       rel="stylesheet"
     />
   </head>

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,12 @@
       "name": "training-diary",
       "version": "0.0.0",
       "dependencies": {
+        "@fullcalendar/core": "^6.1.14",
+        "@fullcalendar/daygrid": "^6.1.14",
+        "@fullcalendar/interaction": "^6.1.14",
+        "@fullcalendar/react": "^6.1.14",
         "axios": "^1.7.2",
+        "date-fns": "^3.6.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-hook-form": "^7.52.1",
@@ -1105,6 +1110,40 @@
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@fullcalendar/core": {
+      "version": "6.1.14",
+      "resolved": "https://registry.npmjs.org/@fullcalendar/core/-/core-6.1.14.tgz",
+      "integrity": "sha512-hIPRBevm0aMc2aHy1hRIJgXmI1QTvQM1neQa9oxtuqUmF1+ApYC3oAdwcQMTuI7lHHw3pKJDyJFkKLPPnL6HXA==",
+      "dependencies": {
+        "preact": "~10.12.1"
+      }
+    },
+    "node_modules/@fullcalendar/daygrid": {
+      "version": "6.1.14",
+      "resolved": "https://registry.npmjs.org/@fullcalendar/daygrid/-/daygrid-6.1.14.tgz",
+      "integrity": "sha512-DSyjiA1dEM8k3bOCrZpZOmAOZu71KGtH02ze+4QKuhxkmn/zQghmmLRdfzpOrcyJg6xGKkoB4pBcO+2lXar8XQ==",
+      "peerDependencies": {
+        "@fullcalendar/core": "~6.1.14"
+      }
+    },
+    "node_modules/@fullcalendar/interaction": {
+      "version": "6.1.14",
+      "resolved": "https://registry.npmjs.org/@fullcalendar/interaction/-/interaction-6.1.14.tgz",
+      "integrity": "sha512-rXum5XCjq+WEPNctFeYL/JKZGeU2rlxrElygocdMegcrIBJQW5hnWWVE+i4/1dOmUKF80CbGVlXUyYXoqK2eFg==",
+      "peerDependencies": {
+        "@fullcalendar/core": "~6.1.14"
+      }
+    },
+    "node_modules/@fullcalendar/react": {
+      "version": "6.1.14",
+      "resolved": "https://registry.npmjs.org/@fullcalendar/react/-/react-6.1.14.tgz",
+      "integrity": "sha512-sXLn2D8aPYLuDH3fy2ZhHTOz5WNSU1NhoECsGBzjUtz2IYHy6m5Y9TqlyqeAqVqFLDRSJAlKAr5LyrIvnD/IMA==",
+      "peerDependencies": {
+        "@fullcalendar/core": "~6.1.14",
+        "react": "^16.7.0 || ^17 || ^18 || ^19",
+        "react-dom": "^16.7.0 || ^17 || ^18 || ^19"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -3727,6 +3766,15 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
+      "integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/debug": {
@@ -7599,6 +7647,15 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="
+    },
+    "node_modules/preact": {
+      "version": "10.12.1",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.12.1.tgz",
+      "integrity": "sha512-l8386ixSsBdbreOAkqtrwqHwdvR35ID8c3rKPa8lCWuO86dBi32QWHV4vfsZK1utLLFMvw+Z5Ad4XLkZzchscg==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "dependencies": {
         "@fullcalendar/core": "^6.1.14",
         "@fullcalendar/daygrid": "^6.1.14",
-        "@fullcalendar/interaction": "^6.1.14",
         "@fullcalendar/react": "^6.1.14",
         "axios": "^1.7.2",
         "date-fns": "^3.6.0",
@@ -1124,14 +1123,6 @@
       "version": "6.1.14",
       "resolved": "https://registry.npmjs.org/@fullcalendar/daygrid/-/daygrid-6.1.14.tgz",
       "integrity": "sha512-DSyjiA1dEM8k3bOCrZpZOmAOZu71KGtH02ze+4QKuhxkmn/zQghmmLRdfzpOrcyJg6xGKkoB4pBcO+2lXar8XQ==",
-      "peerDependencies": {
-        "@fullcalendar/core": "~6.1.14"
-      }
-    },
-    "node_modules/@fullcalendar/interaction": {
-      "version": "6.1.14",
-      "resolved": "https://registry.npmjs.org/@fullcalendar/interaction/-/interaction-6.1.14.tgz",
-      "integrity": "sha512-rXum5XCjq+WEPNctFeYL/JKZGeU2rlxrElygocdMegcrIBJQW5hnWWVE+i4/1dOmUKF80CbGVlXUyYXoqK2eFg==",
       "peerDependencies": {
         "@fullcalendar/core": "~6.1.14"
       }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
   "dependencies": {
     "@fullcalendar/core": "^6.1.14",
     "@fullcalendar/daygrid": "^6.1.14",
-    "@fullcalendar/interaction": "^6.1.14",
     "@fullcalendar/react": "^6.1.14",
     "axios": "^1.7.2",
     "date-fns": "^3.6.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,12 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@fullcalendar/core": "^6.1.14",
+    "@fullcalendar/daygrid": "^6.1.14",
+    "@fullcalendar/interaction": "^6.1.14",
+    "@fullcalendar/react": "^6.1.14",
     "axios": "^1.7.2",
+    "date-fns": "^3.6.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-hook-form": "^7.52.1",

--- a/src/components/Appointment/Calendar/MonthlyCalendar.tsx
+++ b/src/components/Appointment/Calendar/MonthlyCalendar.tsx
@@ -1,0 +1,125 @@
+import FullCalendar from '@fullcalendar/react';
+import dayGridPlugin from '@fullcalendar/daygrid';
+import interactionPlugin from '@fullcalendar/interaction';
+import { DayCellMountArg, DayHeaderContentArg } from '@fullcalendar/core';
+import styled from 'styled-components';
+import { format } from 'date-fns';
+
+const FullCalendarWrapper = styled.div`
+  box-shadow: 0 1px 4px 1px ${({ theme }) => theme.colors.gray300};
+
+  .fc-toolbar.fc-header-toolbar {
+    margin-bottom: 0;
+    padding: 5px;
+    background-color: ${({ theme }) => theme.colors.main500};
+  }
+
+  .fc-toolbar-title {
+    font-family: 'NanumSquareExtraBold';
+    font-size: 2.4rem;
+    color: ${({ theme }) => theme.colors.white};
+    margin-bottom: 0;
+  }
+
+  .fc-button-primary {
+    background-color: transparent;
+    border-radius: 5px;
+    font-size: 1.4rem;
+    padding: 14px 12px;
+    border: none;
+
+    &:hover,
+    &:focus,
+    &:not(:disabled):active {
+      background-color: ${({ theme }) => theme.colors.main200};
+      color: ${({ theme }) => theme.colors.main500};
+      box-shadow: none;
+    }
+  }
+
+  .fc-dayGridMonth-view {
+    padding: 15px 0;
+    font-family: 'Roboto';
+    font-weight: 500;
+    font-style: normal;
+    font-size: 1.5rem;
+    color: ${({ theme }) => theme.colors.gray900};
+  }
+
+  .fc-day-sun {
+    color: ${({ theme }) => theme.colors.red400};
+  }
+
+  .fc-daygrid-day-top {
+    justify-content: center;
+    padding-top: 20px;
+  }
+
+  .fc-daygrid-day.fc-day-today {
+    background-color: transparent;
+  }
+
+  .fc-daygrid-day-number {
+    padding: 2px 3px;
+    border-radius: 3px;
+  }
+
+  .fc-daygrid-day-number.fc-has-event-number {
+    background-color: ${({ theme }) => theme.colors.main400};
+    color: ${({ theme }) => theme.colors.white};
+  }
+
+  .fc-scrollgrid,
+  table,
+  td,
+  th {
+    border: none;
+  }
+
+  .fc-daygrid-day-events {
+    display: none;
+  }
+`;
+
+const dayHeaderContent = (arg: DayHeaderContentArg) => {
+  const dayNames = ['S', 'M', 'T', 'W', 'T', 'F', 'S'];
+  return dayNames[arg.date.getUTCDay()];
+};
+
+const events = [
+  { title: 'event 1', date: '2024-07-25' },
+  { title: 'event 2', date: '2024-07-17' },
+];
+
+const dayCellDidMount = (info: DayCellMountArg) => {
+  const eventDates = events.map((event) => event.date);
+  const formattedDate = format(info.date, 'yyyy-MM-dd');
+  if (eventDates.includes(formattedDate)) {
+    const dayNumberElement = info.el.querySelector('.fc-daygrid-day-number');
+    if (dayNumberElement) {
+      dayNumberElement.classList.add('fc-has-event-number');
+    }
+  }
+};
+
+const MonthlyCalendar: React.FC = () => {
+  return (
+    <FullCalendarWrapper>
+      <FullCalendar
+        plugins={[dayGridPlugin, interactionPlugin]}
+        headerToolbar={{
+          left: 'prev',
+          center: 'title',
+          right: 'next',
+        }}
+        fixedWeekCount={false}
+        height="auto"
+        dayHeaderContent={dayHeaderContent}
+        events={events}
+        dayCellDidMount={dayCellDidMount}
+      />
+    </FullCalendarWrapper>
+  );
+};
+
+export default MonthlyCalendar;

--- a/src/components/Appointment/Calendar/MonthlyCalendar.tsx
+++ b/src/components/Appointment/Calendar/MonthlyCalendar.tsx
@@ -1,6 +1,5 @@
 import FullCalendar from '@fullcalendar/react';
 import dayGridPlugin from '@fullcalendar/daygrid';
-import interactionPlugin from '@fullcalendar/interaction';
 import { DayCellMountArg, DayHeaderContentArg } from '@fullcalendar/core';
 import styled from 'styled-components';
 import { format } from 'date-fns';
@@ -106,7 +105,7 @@ const MonthlyCalendar: React.FC = () => {
   return (
     <FullCalendarWrapper>
       <FullCalendar
-        plugins={[dayGridPlugin, interactionPlugin]}
+        plugins={[dayGridPlugin]}
         headerToolbar={{
           left: 'prev',
           center: 'title',

--- a/src/components/Appointment/Calendar/MonthlyCalendar.tsx
+++ b/src/components/Appointment/Calendar/MonthlyCalendar.tsx
@@ -4,8 +4,10 @@ import { DayCellMountArg, DayHeaderContentArg } from '@fullcalendar/core';
 import styled from 'styled-components';
 import { format } from 'date-fns';
 
+import { hexToRgba } from 'src/utils/hexToRgba';
+
 const FullCalendarWrapper = styled.div`
-  box-shadow: 0 1px 4px 1px ${({ theme }) => theme.colors.gray300};
+  box-shadow: 0 4px 4px ${({ theme }) => hexToRgba(theme.colors.black, 0.25)};
 
   .fc-toolbar.fc-header-toolbar {
     margin-bottom: 0;
@@ -27,20 +29,27 @@ const FullCalendarWrapper = styled.div`
     padding: 14px 12px;
     border: none;
 
-    &:hover,
-    &:focus,
+    &:hover {
+      background-color: transparent;
+    }
+
     &:not(:disabled):active {
       background-color: ${({ theme }) => theme.colors.main200};
       color: ${({ theme }) => theme.colors.main500};
+    }
+
+    &:not(:disabled):active:focus {
+      box-shadow: none;
+    }
+
+    &:focus {
       box-shadow: none;
     }
   }
 
   .fc-dayGridMonth-view {
     padding: 15px 0;
-    font-family: 'Roboto';
-    font-weight: 500;
-    font-style: normal;
+    font-family: 'NanumSquareBold';
     font-size: 1.5rem;
     color: ${({ theme }) => theme.colors.gray900};
   }

--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -26,9 +26,12 @@ const Tab = styled.button<{ $isActive: boolean }>`
   flex: 1;
   padding: 10px 0;
   border: none;
-  color: ${({ $isActive, theme }) => ($isActive ? theme.colors.gray900 : theme.colors.gray700)};
-  background: ${({ $isActive, theme }) => ($isActive ? theme.colors.white : 'transparent')};
-  font-family: ${({ $isActive }) => ($isActive ? "'NanumSquareBold' !important" : 'NanumSquare')};
+  color: ${({ $isActive, theme }) =>
+    $isActive ? theme.colors.gray900 : theme.colors.gray700};
+  background: ${({ $isActive, theme }) =>
+    $isActive ? theme.colors.white : 'transparent'};
+  font-family: ${({ $isActive }) =>
+    $isActive ? "'NanumSquareBold' !important" : 'NanumSquare'};
   box-shadow: ${({ $isActive, theme }) =>
     $isActive ? `0 2px 10px 1px ${theme.colors.gray400}` : 'none'};
   font-size: 1.2rem;
@@ -76,7 +79,11 @@ const Tabs: React.FC<TabsProps> = ({ tabs }) => {
     <Wrapper>
       <TabWrapper>
         {tabs.map((tab, index) => (
-          <Tab key={index} $isActive={activeIndex === index} onClick={() => setActiveIndex(index)}>
+          <Tab
+            key={index}
+            $isActive={activeIndex === index}
+            onClick={() => setActiveIndex(index)}
+          >
             {tab.label}
           </Tab>
         ))}

--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -53,12 +53,6 @@ const TabPanel = styled.div`
   width: 100%;
   max-width: calc(100% - 40px);
   margin: 20px auto 0;
-  padding: 10px;
-  background: #fff;
-  border: 1px solid #ccc;
-
-  // todo : 없앨 것
-  padding: 50% 0;
 `;
 
 // TabItem 타입 정의

--- a/src/routes/Appointment/Appointment.tsx
+++ b/src/routes/Appointment/Appointment.tsx
@@ -1,14 +1,16 @@
 import Tabs from '@components/Tabs/Tabs';
+import MonthlyContent from './MonthlyContent';
+import WeeklyContent from './WeeklyContent';
 
 const Appointment: React.FC = () => {
   const tabs = [
     {
       label: '월별',
-      content: <div>Tab 1 Content</div>,
+      content: <MonthlyContent />,
     },
     {
       label: '주별',
-      content: <div>Tab 2 Content</div>,
+      content: <WeeklyContent />,
     },
   ];
 

--- a/src/routes/Appointment/MonthlyContent.tsx
+++ b/src/routes/Appointment/MonthlyContent.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const MonthlyContent: React.FC = () => {
+  return <div>월별 콘텐츠</div>;
+};
+
+export default MonthlyContent;

--- a/src/routes/Appointment/MonthlyContent.tsx
+++ b/src/routes/Appointment/MonthlyContent.tsx
@@ -1,7 +1,13 @@
-import React from 'react';
+import React, { Fragment } from 'react';
+
+import MonthlyCalendar from '@components/Appointment/Calendar/MonthlyCalendar';
 
 const MonthlyContent: React.FC = () => {
-  return <div>월별 콘텐츠</div>;
+  return (
+    <Fragment>
+      <MonthlyCalendar />
+    </Fragment>
+  );
 };
 
 export default MonthlyContent;

--- a/src/routes/Appointment/WeeklyContent.tsx
+++ b/src/routes/Appointment/WeeklyContent.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const WeeklyContent: React.FC = () => {
+  return <div>주별 콘텐츠</div>;
+};
+
+export default WeeklyContent;

--- a/src/routes/Layout.tsx
+++ b/src/routes/Layout.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
+import { Outlet } from 'react-router-dom';
 
 import Header from '@components/Header/Header';
 import Navigation from '@components/Navigation/Navigation';
-import { Outlet } from 'react-router-dom';
 
 const Layout: React.FC = () => {
   return (

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -4,7 +4,7 @@ import Home from './Home';
 import Login from './Login';
 import Signup from './Signup';
 import Layout from './Layout';
-import Appointment from './Appointment';
+import Appointment from './Appointment/Appointment';
 
 const router = createBrowserRouter([
   {


### PR DESCRIPTION
### 📝 관련 이슈
closed #15 

### ✨ 반영 브랜치
<!-- 어떤 브랜치에서 어떤 브랜치로 merge하는지 적어주세요 -->
- FROM: `15-feat/month-calendar-view`
- TO: `master`

### ✅ PR 내용
- [x] Calendar 구현을 위한 라이브러리 설치
> - `@fullcalendar/react`: FullCalendar를 React 컴포넌트로 사용하기 위한 패키지
> - `@fullcalendar/daygrid`: 일(day)을 grid 형식으로 배치한 주간, 월간 뷰를 제공하는 플러그인
> - `@fullcalendar/core`: FullCalendar에서 사용하는 함수 인자의 타입지정, FullCalendar의 기본 설정과 동작 관리 패키지
> - `date-fns`: Javascript에서 날짜와 시간을 처리하기 위한 유틸리티 라이브러리

- [x] `MonthlyCalendar` 컴포넌트 구현
> - 예약 페이지 > 월별 시간표 탭 > calendar 섹션에서 사용되는 컴포넌트
> - FullCalendar 컴포넌트 import해서 props로 제공하는 기능 설정 (header의 구성, 달력 길이 자동 조정, 요일 커스텀, 이벤트 날짜 지정 등)
> - CSS 부분은 커스텀하기 위해 부모 컴포넌트인 FullCalendarWrapper를 만들어 FullCalendar의 클래스 오버라이드 (덮어쓰기)
> - 디자인, 기획적으로 추가 논의 필요한 부분은 ETC 기재

- [x] Appointment 관련 폴더구조 정리
> - `routes` > `Appointment` > `Appointment` (예약 페이지), `MonthlyContent` (예약페이지 >월간 탭), `WeeklyContent` (예약페이지 > 주간 탭) 3개의 파일로 구분
> - `components` > `Appointment` > `Calendar` > `MonthlyCalendar` 컴포넌트 파일 추가

- [x] Calendar에 사용할 `roboto` 폰트 추가
> - `index.html`에 link 태그 삽입

- [x] Tabs 컴포넌트의 TabPanel에 필요없는 padding 삭제
> - 좌우여백 20px 이미 적용되어 있는 상태

### 🌐 테스트 배포
<!-- 모바일 기기에서 진행한 테스트에 대해 적어주세요 -->
- [x] 테스트 배포하여 잘 동작하는 지 확인했나요?
> - 테스트 배포 주소: https://sumin-test-training-diary.netlify.app/appointment
> - 테스트 환경 (Desktop): MacOS (Chrome / Safari / Firefox / Edge)
> - 테스트 환경 (Mobile): Android (Chrome / 삼성인터넷)

### 📸 스크린샷
<img width="438" alt="image" src="https://github.com/TrainingDiary/training-diary-frontend/assets/109029407/b815318b-9c87-4ea8-8837-46bc507caa03">

### 📌 ETC
- 새로 설치된 패키지들이 있습니다. `git pull` 하시고 `npm ci`로 패키지 설치해주세요!
- 이미 CSS가 잡혀있는 FullCalendar 컴포넌트에 CSS를 오버라이딩하는 거라서 `margin`이나 `padding` 등의 여백은 피그마 디자인과 완벽하게 동일하지 못합니다 🥲 최대한 똑같이 구현해보려고 했는데, 아쉬운 부분이 있다면 말씀주시면 추가 수정하겠습니다!
- 달력의 `Header`는 나눔스퀘어ExtraBold, `Body`는 roboto medium 적용하고 `font-size`도 피그마와 동일하게 적용했는데 브라우저에서 볼 때 다르게 보이는 것 같습니다. 저의 테스트 배포 채널에서 한번 확인 부탁드립니다 🙇‍♂️
- 달력에서 오늘 날짜 표시, 일정 있는 날짜 표시, 일괄 등록 버튼을 눌러서 선택한 날짜 표시, 이미 일정 있는 날짜 표시 등 스타일이 구분되어야 할 경우가 있는 것 같습니다! 해당 부분 기획이나 디자인 의논 후 추가 반영하겠습니다.
- 달력의 `box-shadow` 값을 피그마에서 찾지 못해서(죄송합니다😭) 임의 설정 해놓은 상태입니다. `box-shadow` 값 확인부탁드립니다.
