### PR TITLE
[FIX] 모달 테스트 코드 수정 #17

### DIFF
--- a/src/components/Common/Modal/Modal.test.tsx
+++ b/src/components/Common/Modal/Modal.test.tsx
@@ -14,31 +14,19 @@ const renderWithTheme = (component: React.ReactElement) => {
 describe('Modal 컴포넌트 테스트', () => {
   test('모달이 열렸을 때 렌더링 되어야 한다.', () => {
     renderWithTheme(
-      <Modal
-        title="테스트 모달"
-        type="confirm"
-        isOpen={true}
-        onClose={() => {}}
-      >
+      <Modal title="테스트 모달" type="confirm" isOpen={true} onClose={() => {}}>
         정말로 이 작업을 수행하시겠습니까?
       </Modal>
     );
 
     expect(screen.getByRole('dialog')).toBeInTheDocument();
     expect(screen.getByText('테스트 모달')).toBeInTheDocument();
-    expect(
-      screen.getByText('정말로 이 작업을 수행하시겠습니까?')
-    ).toBeInTheDocument();
+    expect(screen.getByText('정말로 이 작업을 수행하시겠습니까?')).toBeInTheDocument();
   });
 
   test('모달이 닫혔을 때 렌더링 되지 않아야 한다.', () => {
     renderWithTheme(
-      <Modal
-        title="테스트 모달"
-        type="confirm"
-        isOpen={false}
-        onClose={() => {}}
-      >
+      <Modal title="테스트 모달" type="confirm" isOpen={false} onClose={() => {}}>
         정말로 이 작업을 수행하시겠습니까?
       </Modal>
     );
@@ -62,13 +50,7 @@ describe('Modal 컴포넌트 테스트', () => {
   test('저장 버튼 클릭 시 onSave 함수가 호출되어야 한다.', () => {
     const handleSave = jest.fn();
     renderWithTheme(
-      <Modal
-        title="입력 모달"
-        type="input"
-        isOpen={true}
-        onClose={() => {}}
-        onSave={handleSave}
-      >
+      <Modal title="입력 모달" type="input" isOpen={true} onClose={() => {}} onSave={handleSave}>
         입력할 내용을 적어주세요.
       </Modal>
     );
@@ -76,7 +58,7 @@ describe('Modal 컴포넌트 테스트', () => {
     const input = screen.getByPlaceholderText('입력할 내용을 적어주세요.');
     fireEvent.change(input, { target: { value: '새 입력값' } });
 
-    const saveButton = screen.getByText('추가');
+    const saveButton = screen.getByText('저장');
     fireEvent.click(saveButton);
 
     expect(handleSave).toHaveBeenCalledWith('새 입력값');

--- a/src/components/Common/Modal/Modal.test.tsx
+++ b/src/components/Common/Modal/Modal.test.tsx
@@ -14,19 +14,31 @@ const renderWithTheme = (component: React.ReactElement) => {
 describe('Modal 컴포넌트 테스트', () => {
   test('모달이 열렸을 때 렌더링 되어야 한다.', () => {
     renderWithTheme(
-      <Modal title="테스트 모달" type="confirm" isOpen={true} onClose={() => {}}>
+      <Modal
+        title="테스트 모달"
+        type="confirm"
+        isOpen={true}
+        onClose={() => {}}
+      >
         정말로 이 작업을 수행하시겠습니까?
       </Modal>
     );
 
     expect(screen.getByRole('dialog')).toBeInTheDocument();
     expect(screen.getByText('테스트 모달')).toBeInTheDocument();
-    expect(screen.getByText('정말로 이 작업을 수행하시겠습니까?')).toBeInTheDocument();
+    expect(
+      screen.getByText('정말로 이 작업을 수행하시겠습니까?')
+    ).toBeInTheDocument();
   });
 
   test('모달이 닫혔을 때 렌더링 되지 않아야 한다.', () => {
     renderWithTheme(
-      <Modal title="테스트 모달" type="confirm" isOpen={false} onClose={() => {}}>
+      <Modal
+        title="테스트 모달"
+        type="confirm"
+        isOpen={false}
+        onClose={() => {}}
+      >
         정말로 이 작업을 수행하시겠습니까?
       </Modal>
     );
@@ -50,7 +62,13 @@ describe('Modal 컴포넌트 테스트', () => {
   test('저장 버튼 클릭 시 onSave 함수가 호출되어야 한다.', () => {
     const handleSave = jest.fn();
     renderWithTheme(
-      <Modal title="입력 모달" type="input" isOpen={true} onClose={() => {}} onSave={handleSave}>
+      <Modal
+        title="입력 모달"
+        type="input"
+        isOpen={true}
+        onClose={() => {}}
+        onSave={handleSave}
+      >
         입력할 내용을 적어주세요.
       </Modal>
     );
@@ -58,7 +76,7 @@ describe('Modal 컴포넌트 테스트', () => {
     const input = screen.getByPlaceholderText('입력할 내용을 적어주세요.');
     fireEvent.change(input, { target: { value: '새 입력값' } });
 
-    const saveButton = screen.getByText('저장');
+    const saveButton = screen.getByText('추가');
     fireEvent.click(saveButton);
 
     expect(handleSave).toHaveBeenCalledWith('새 입력값');


### PR DESCRIPTION
### 📝 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
closed #17 

### ✨ 반영 브랜치
<!-- 어떤 브랜치에서 어떤 브랜치로 merge하는지 적어주세요 -->
- FROM: `17-feat/home-trainee-list-view`
- TO: `master`

### ✅ PR 내용
<!-- 기능마다 아래 템플릿으로 PR에 대한 설명을 적어주세요 (기능별 AS-IS, TO-BE, 변경이유 등) -->
- [x] 모달 테스트 코드 수정
> - AS-IS: 기존 모달 버튼의 내용은 `저장`으로 고정되어 있었습니다.
> - TO-BE: 모달 버튼의 내용을 직접 받거나 `추가`로 변경했습니다.
> - Description: props btnConfirm로 받아서 직접 원하는 내용으로 바꿀 수 있도록 변경했습니다. 조건부로 받기 때문에 받지 않으면 `추가`로 보여지게 되었습니다.
```typescript
const saveButton = screen.getByText('저장');
    fireEvent.click(saveButton);

const saveButton = screen.getByText('추가');
    fireEvent.click(saveButton);
```


### 🌐 테스트 배포
<!-- 모바일 기기에서 진행한 테스트에 대해 적어주세요 -->
- [x] 테스트 배포하여 잘 동작하는 지 확인했나요?
> - 테스트 배포 주소: https://test-training-diary.netlify.app/
> - 테스트 환경 (Desktop): Windows(Chrome / Firefox / Edge)
> - 테스트 환경 (Mobile): ios (Safari)

### 📸 스크린샷
<!-- 가능하다면 스크린샷을 첨부해주세요 (Optional) -->

### 📌 ETC
<!-- 레퍼런스, 참고할 사항, 질문 사항이 있다면 적어주세요 (Optional) -->
