### PR TITLE
[FEAT] Workout list 추가, 수정 모달 추가 및 Drawer 디자인 및 기능 리팩토링 #30

### DIFF
--- a/src/components/Common/Modal/Modal.tsx
+++ b/src/components/Common/Modal/Modal.tsx
@@ -16,7 +16,7 @@ const ModalWrapper = styled.div<{ $isOpen: boolean }>`
   display: ${({ $isOpen }) => ($isOpen ? 'flex' : 'none')};
   justify-content: center;
   align-items: center;
-  z-index: 1000;
+  z-index: 1003;
   max-width: 450px;
   transform: translateX(-50%);
 `;

--- a/src/components/Header/Drawer.tsx
+++ b/src/components/Header/Drawer.tsx
@@ -106,8 +106,10 @@ const Drawer: React.FC<DrawerProps> = ({ $isOpen, onClose, onLogout }) => {
   useEffect(() => {
     if ($isOpen) {
       document.body.style.overflow = 'hidden';
+      document.body.style.height = 'auto';
     } else {
       document.body.style.overflow = 'unset';
+      document.body.style.height = '100vh';
     }
 
     return () => {

--- a/src/components/Header/Drawer.tsx
+++ b/src/components/Header/Drawer.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import styled from 'styled-components';
 import { Link } from 'react-router-dom';
 
@@ -11,25 +11,56 @@ const DrawerWrapper = styled.div<{ $isOpen: boolean }>`
   position: absolute;
   top: 0;
   right: 0;
-  width: 300px;
+  width: 250px;
   height: 100%;
   background-color: ${({ theme }) => theme.colors.white};
-  box-shadow: -2px 0 5px ${({ theme }) => hexToRgba(theme.colors.black, 0.2)};
+  box-shadow: -2px 0 8px ${({ theme }) => hexToRgba(theme.colors.black, 0.3)};
   transform: ${({ $isOpen }) =>
     $isOpen ? 'translateX(0)' : 'translateX(120%)'};
-  transition: transform 0.3s ease;
+  transition: transform 0.3s ease-in-out;
   display: flex;
   flex-direction: column;
   padding: 20px;
   z-index: 1002;
 `;
 
+const DrawerHeader = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding-bottom: 20px;
+  border-bottom: 1px solid ${({ theme }) => theme.colors.gray300};
+  margin-bottom: 20px;
+`;
+
+const DrawerTitle = styled.h2`
+  font-size: 1.8rem;
+  color: ${({ theme }) => theme.colors.main500};
+  margin: 0;
+  font-family: 'NanumSquareExtraBold';
+`;
+
+const DrawerCloseButton = styled.button`
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 1.6rem;
+  color: ${({ theme }) => theme.colors.gray900};
+  line-height: 1;
+`;
+
 const DrawerItem = styled(Link)`
   display: flex;
   align-items: center;
-  padding: 10px 0;
+  padding: 15px 0;
   color: ${({ theme }) => theme.colors.gray900};
   text-decoration: none;
+  font-size: 1.4rem;
+  gap: 15px;
+  border-bottom: solid 1px ${({ theme }) => theme.colors.gray200};
+  &:hover {
+    background-color: ${({ theme }) => hexToRgba(theme.colors.main500, 0.1)};
+  }
   img {
     margin-right: 10px;
   }
@@ -38,13 +69,31 @@ const DrawerItem = styled(Link)`
 const DrawerItemDiv = styled.div`
   display: flex;
   align-items: center;
-  padding: 10px 0;
+  padding: 15px 0;
   color: ${({ theme }) => theme.colors.gray900};
   text-decoration: none;
+  font-size: 1.4rem;
+  gap: 15px;
   cursor: pointer;
+  border-bottom: solid 1px ${({ theme }) => theme.colors.gray200};
+  &:hover {
+    background-color: ${({ theme }) => hexToRgba(theme.colors.main500, 0.1)};
+  }
   img {
     margin-right: 10px;
   }
+`;
+
+const DrawerBg = styled.div<{ $isOpen: boolean }>`
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  left: 0;
+  top: 0;
+  z-index: 1001;
+  background-color: ${({ theme }) => hexToRgba(theme.colors.gray900, 0.2)};
+  transform: ${({ $isOpen }) =>
+    $isOpen ? 'translateX(0)' : 'translateX(120%)'};
 `;
 
 interface DrawerProps {
@@ -54,26 +103,44 @@ interface DrawerProps {
 }
 
 const Drawer: React.FC<DrawerProps> = ({ $isOpen, onClose, onLogout }) => {
+  useEffect(() => {
+    if ($isOpen) {
+      document.body.style.overflow = 'hidden';
+    } else {
+      document.body.style.overflow = 'unset';
+    }
+
+    return () => {
+      document.body.style.overflow = 'unset';
+    };
+  }, [$isOpen]);
   return (
-    <DrawerWrapper $isOpen={$isOpen}>
-      <DrawerItem to="/" onClick={onClose}>
-        <img src={homeIcon} alt="Home" />
-        Home
-      </DrawerItem>
-      <DrawerItem to="/appointment" onClick={onClose}>
-        <img src={appointmentIcon} alt="Appointment" />
-        Appointment
-      </DrawerItem>
-      <DrawerItemDiv
-        onClick={() => {
-          onClose();
-          onLogout();
-        }}
-      >
-        <img src={logOutIcon} alt="Logout" />
-        Logout
-      </DrawerItemDiv>
-    </DrawerWrapper>
+    <React.Fragment>
+      <DrawerWrapper $isOpen={$isOpen}>
+        <DrawerHeader>
+          <DrawerTitle>Menu</DrawerTitle>
+          <DrawerCloseButton onClick={onClose}>✕</DrawerCloseButton>
+        </DrawerHeader>
+        <DrawerItem to="/" onClick={onClose}>
+          <img src={homeIcon} alt="Home" />
+          Home
+        </DrawerItem>
+        <DrawerItem to="/appointment" onClick={onClose}>
+          <img src={appointmentIcon} alt="Appointment" />
+          Appointment
+        </DrawerItem>
+        <DrawerItemDiv
+          onClick={() => {
+            onClose();
+            onLogout();
+          }}
+        >
+          <img src={logOutIcon} alt="Logout" />
+          Logout
+        </DrawerItemDiv>
+      </DrawerWrapper>
+      <DrawerBg $isOpen={$isOpen} onClick={onClose} />
+    </React.Fragment>
   );
 };
 

--- a/src/components/Header/Drawer.tsx
+++ b/src/components/Header/Drawer.tsx
@@ -104,16 +104,17 @@ interface DrawerProps {
 
 const Drawer: React.FC<DrawerProps> = ({ $isOpen, onClose, onLogout }) => {
   useEffect(() => {
+    const $root = document.getElementById('root');
+    if (!$root) return;
     if ($isOpen) {
-      document.body.style.overflow = 'hidden';
-      document.body.style.height = 'auto';
+      $root.style.overflow = 'hidden';
     } else {
-      document.body.style.overflow = 'unset';
-      document.body.style.height = '100vh';
+      $root.style.overflow = 'unset';
+      $root.style.overflowX = 'hidden';
     }
-
     return () => {
-      document.body.style.overflow = 'unset';
+      $root.style.overflow = 'unset';
+      $root.style.overflowX = 'hidden';
     };
   }, [$isOpen]);
   return (

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import styled from 'styled-components';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { Link, useLocation, useNavigate } from 'react-router-dom';
 
 import backIcon from '@icons/header/backIcon.svg';
 import bellIcon from '@icons/header/bell.svg';
@@ -20,12 +20,18 @@ const HeaderWrapper = styled.header`
   padding: 20px;
   line-height: 1;
 
-  h1 {
+  a {
+    display: block;
     font-size: 2.4rem;
     position: absolute;
     left: 50%;
     transform: translateX(-50%);
     margin: 0;
+    text-decoration: none;
+    color: ${({ theme }) => theme.colors.gray900};
+  }
+
+  h1 {
   }
 `;
 
@@ -81,7 +87,9 @@ const Header: React.FC = () => {
               )}
           </BackIcon>
         </IconWrapper>
-        <h1>트.다</h1>
+        <Link to={'/'}>
+          <h1>트.다</h1>
+        </Link>
         <IconWrapper>
           <Icon>
             <img src={bellIcon} alt="Bell" />

--- a/src/mocks/data/workoutList.ts
+++ b/src/mocks/data/workoutList.ts
@@ -17,7 +17,7 @@ export const workoutList = [
     name: '스쿼트',
     target_muscle: '다리',
     remark:
-      '무릎이 발끝을 넘지 않도록 하세요. 편하게 갈 수 있는 만큼 깊이 내려가세요.',
+      '무릎이 발끝을 넘지 않도록 하세요. 편하게 갈 수 있는 만큼 깊이 내려가세요.무릎이 발끝을 넘지 않도록 하세요. 편하게 갈 수 있는 만큼 깊이 내려가세요.무릎이 발끝을 넘지 않도록 하세요. 편하게 갈 수 있는 만큼 깊이 내려가세요.',
     weight_input_required: true,
     set_input_required: true,
     rep_input_required: true,

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -20,7 +20,7 @@ export const handlers = [
     return HttpResponse.json(traineeList);
   }),
 
-  http.get('api/workout-types', () => {
+  http.get('/api/workout-types', () => {
     return HttpResponse.json(workoutList);
   }),
 ];

--- a/src/routes/Trainer/AddWorkOutModal.tsx
+++ b/src/routes/Trainer/AddWorkOutModal.tsx
@@ -25,6 +25,17 @@ const Input = styled.input`
   width: 100%;
 `;
 
+const TextArea = styled.textarea`
+  padding: 10px;
+  border: 1px solid ${({ theme }) => theme.colors.gray300};
+  border-radius: 5px;
+  outline: none;
+  width: 100%;
+  font-family: 'NanumSquare', 'NotoSans KR', system-ui, -apple-system,
+    BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell,
+    'Open Sans', 'Helvetica Neue', sans-serif;
+`;
+
 const CheckboxGroup = styled.div`
   display: flex;
   gap: 10px;
@@ -150,11 +161,11 @@ const AddWorkOutModal: React.FC<AddWorkOutModalProps> = ({
       </FormGroup>
       <FormGroup>
         <Label>주의사항 노트:</Label>
-        <Input
+        <TextArea
           type="text"
           value={remark}
           onChange={(e) => setRemark(e.target.value)}
-        />
+        ></TextArea>
       </FormGroup>
       <FormGroup>
         <Label>속성 값:</Label>

--- a/src/routes/Trainer/AddWorkOutModal.tsx
+++ b/src/routes/Trainer/AddWorkOutModal.tsx
@@ -1,0 +1,189 @@
+import React, { useState, useEffect } from 'react';
+import styled from 'styled-components';
+
+import Modal from '@components/Common/Modal/Modal';
+import { WorkoutDataType } from './WorkOutManagement';
+
+// 스타일 정의
+const FormGroup = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  align-items: flex-start;
+`;
+
+const Label = styled.label`
+  font-size: 1.4rem;
+  color: ${({ theme }) => theme.colors.gray900};
+`;
+
+const Input = styled.input`
+  padding: 10px;
+  border: 1px solid ${({ theme }) => theme.colors.gray300};
+  border-radius: 5px;
+  outline: none;
+  width: 100%;
+`;
+
+const CheckboxGroup = styled.div`
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+`;
+
+const CheckboxLabel = styled.label`
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  color: ${({ theme }) => theme.colors.gray600};
+  background-color: ${({ theme }) => theme.colors.gray100};
+  padding: 5px 10px;
+  border-radius: 5px;
+  cursor: pointer;
+
+  input {
+    display: none;
+  }
+
+  &.selected {
+    background-color: ${({ theme }) => theme.colors.main400};
+    color: ${({ theme }) => theme.colors.white};
+  }
+`;
+
+interface AddWorkOutModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSave: (workout: WorkoutDataType) => void;
+  initialData?: WorkoutDataType | null; // 기존 데이터를 받을 수 있도록 수정
+}
+
+const AddWorkOutModal: React.FC<AddWorkOutModalProps> = ({
+  isOpen,
+  onClose,
+  onSave,
+  initialData = null, // 기본값을 null로 설정
+}) => {
+  const [name, setName] = useState('');
+  const [targetMuscle, setTargetMuscle] = useState('');
+  const [remark, setRemark] = useState('');
+  const [attributes, setAttributes] = useState({
+    weight: false,
+    set: false,
+    rep: false,
+    time: false,
+    speed: false,
+  });
+
+  // 모달이 열릴 때 초기 데이터를 설정
+  useEffect(() => {
+    if (initialData) {
+      setName(initialData.name);
+      setTargetMuscle(initialData.target_muscle);
+      setRemark(initialData.remark);
+      setAttributes({
+        weight: initialData.weight_input_required,
+        set: initialData.set_input_required,
+        rep: initialData.rep_input_required,
+        time: initialData.time_input_required,
+        speed: initialData.speed_input_required,
+      });
+    } else {
+      // 초기화
+      setName('');
+      setTargetMuscle('');
+      setRemark('');
+      setAttributes({
+        weight: false,
+        set: false,
+        rep: false,
+        time: false,
+        speed: false,
+      });
+    }
+  }, [initialData]);
+
+  const handleAttributeChange = (attr: keyof typeof attributes) => {
+    setAttributes((prev) => ({ ...prev, [attr]: !prev[attr] }));
+  };
+
+  const handleSave = () => {
+    const newWorkout: WorkoutDataType = {
+      id: initialData?.id || Date.now(), // 임시 ID 또는 기존 ID 사용
+      name,
+      target_muscle: targetMuscle,
+      remark,
+      weight_input_required: attributes.weight,
+      set_input_required: attributes.set,
+      rep_input_required: attributes.rep,
+      time_input_required: attributes.time,
+      speed_input_required: attributes.speed,
+    };
+    onSave(newWorkout);
+    onClose();
+  };
+
+  return (
+    <Modal
+      title={initialData ? '운동 종류 수정' : '운동 종류 추가'}
+      type="custom"
+      isOpen={isOpen}
+      onClose={onClose}
+      onSave={handleSave}
+      btnConfirm={initialData ? '수정' : '추가'}
+    >
+      <FormGroup>
+        <Label>운동명:</Label>
+        <Input
+          type="text"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+        />
+      </FormGroup>
+      <FormGroup>
+        <Label>주요 자극 부위:</Label>
+        <Input
+          type="text"
+          value={targetMuscle}
+          onChange={(e) => setTargetMuscle(e.target.value)}
+        />
+      </FormGroup>
+      <FormGroup>
+        <Label>주의사항 노트:</Label>
+        <Input
+          type="text"
+          value={remark}
+          onChange={(e) => setRemark(e.target.value)}
+        />
+      </FormGroup>
+      <FormGroup>
+        <Label>속성 값:</Label>
+        <CheckboxGroup>
+          {Object.keys(attributes).map((attr) => (
+            <CheckboxLabel
+              key={attr}
+              className={
+                attributes[attr as keyof typeof attributes] ? 'selected' : ''
+              }
+            >
+              <input
+                type="checkbox"
+                checked={attributes[attr as keyof typeof attributes]}
+                onChange={() =>
+                  handleAttributeChange(attr as keyof typeof attributes)
+                }
+              />
+              {attr === 'weight' && '무게'}
+              {attr === 'set' && '세트'}
+              {attr === 'rep' && '횟수'}
+              {attr === 'time' && '시간'}
+              {attr === 'speed' && '속도'}
+            </CheckboxLabel>
+          ))}
+        </CheckboxGroup>
+      </FormGroup>
+    </Modal>
+  );
+};
+
+export default AddWorkOutModal;

--- a/src/routes/Trainer/AddWorkOutModal.tsx
+++ b/src/routes/Trainer/AddWorkOutModal.tsx
@@ -35,7 +35,6 @@ const TextArea = styled.textarea`
     BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell,
     'Open Sans', 'Helvetica Neue', sans-serif;
   resize: none;
-  max-height: 90px;
 `;
 
 const CheckboxGroup = styled.div`

--- a/src/routes/Trainer/AddWorkOutModal.tsx
+++ b/src/routes/Trainer/AddWorkOutModal.tsx
@@ -162,7 +162,6 @@ const AddWorkOutModal: React.FC<AddWorkOutModalProps> = ({
       <FormGroup>
         <Label>주의사항 노트:</Label>
         <TextArea
-          type="text"
           value={remark}
           onChange={(e) => setRemark(e.target.value)}
         ></TextArea>

--- a/src/routes/Trainer/TraineeManagement.tsx
+++ b/src/routes/Trainer/TraineeManagement.tsx
@@ -28,17 +28,17 @@ const DropDownWrapper = styled.div`
     width: 100%;
     border-radius: 5px;
     border: none;
-    appearance: none;
+    /* appearance: none; */
     padding: 10px;
     border-radius: 5px;
     background-color: ${({ theme }) => theme.colors.white};
     border: 1px solid ${({ theme }) => theme.colors.gray300};
     box-shadow: 0 1px 4px 0 ${({ theme }) => hexToRgba(theme.colors.black, 0.2)};
     font-size: 1.2rem;
-    background-image: url('/src/assets/icons/home/dropDownArrow.svg');
+    /* background-image: url('/src/assets/icons/home/dropDownArrow.svg');
     background-position: 97% center;
     background-repeat: no-repeat;
-    background-size: auto;
+    background-size: auto; */
 
     &:focus {
       outline: none;

--- a/src/routes/Trainer/WorkOutManagement.tsx
+++ b/src/routes/Trainer/WorkOutManagement.tsx
@@ -6,6 +6,8 @@ import addBtn from '@icons/home/addbtn.svg';
 import { AddButton } from './TraineeManagement';
 import Modal from '@components/Common/Modal/Modal';
 import Card from './Card';
+import useModals from 'src/hooks/useModals';
+import AddWorkOutModal from './AddWorkOutModal';
 
 const Wrapper = styled.div`
   display: flex;
@@ -16,7 +18,7 @@ const Wrapper = styled.div`
 `;
 
 // msw data type 정의
-interface WorkoutDataType {
+export interface WorkoutDataType {
   id: number;
   name: string;
   target_muscle: string;
@@ -29,11 +31,12 @@ interface WorkoutDataType {
 }
 
 const WorkOutManagement: React.FC = () => {
+  const { openModal, closeModal, isOpen } = useModals();
   const [workouts, setWorkouts] = useState<WorkoutDataType[]>([]);
-  const [isConfirmModalOpen, setConfirmModalOpen] = useState(false);
   const [selectedWorkoutId, setSelectedWorkoutId] = useState<number | null>(
     null
   );
+  const [initialData, setInitialData] = useState<WorkoutDataType | null>(null); // 수정
 
   // msw 데이터 불러오기
   useEffect(() => {
@@ -49,14 +52,35 @@ const WorkOutManagement: React.FC = () => {
     fetchWorkouts();
   }, []);
 
-  const handleOpenConfirmModal = (id: number) => {
-    setSelectedWorkoutId(id);
-    setConfirmModalOpen(true);
+  const handleOpenAddModal = () => {
+    openModal('addModal');
   };
 
-  const handleCloseConfirmModal = () => {
+  const handleCloseAddModal = () => {
     setSelectedWorkoutId(null);
-    setConfirmModalOpen(false);
+    closeModal('addModal');
+  };
+
+  // 수정 버튼
+  const handleOpenEditModal = (workout: WorkoutDataType) => {
+    setInitialData(workout);
+    openModal('addModal');
+  };
+
+  const handleOpenDeleteModal = (id: number) => {
+    setSelectedWorkoutId(id);
+    openModal('deleteModal');
+  };
+
+  const handleCloseDeleteModal = () => {
+    setSelectedWorkoutId(null);
+    closeModal('deleteModal');
+  };
+
+  // TODO : 추가 적용
+  const handleSaveInput = (value?: string) => {
+    console.log(`Saved value: ${value}`);
+    closeModal('addModal');
   };
 
   // TODO : delete api 추후 적용
@@ -66,7 +90,7 @@ const WorkOutManagement: React.FC = () => {
         prevWorkouts.filter((workout) => workout.id !== selectedWorkoutId)
       );
     }
-    setConfirmModalOpen(false);
+    closeModal('deleteModal');
   };
 
   const getWorkoutName = (id: number | null) => {
@@ -81,25 +105,31 @@ const WorkOutManagement: React.FC = () => {
         <Card
           key={workout.id}
           workout={workout}
-          onDelete={handleOpenConfirmModal}
-          onEdit={() => console.log('Edit workout', workout.id)}
+          onDelete={handleOpenDeleteModal}
+          onEdit={() => handleOpenEditModal(workout)}
         />
       ))}
       {/* Add button 추가 */}
-      <AddButton>
+      <AddButton onClick={handleOpenAddModal}>
         <img src={addBtn} alt="add button" />
       </AddButton>
       <Modal
         title="운동 종류 삭제"
         type="confirm"
-        isOpen={isConfirmModalOpen}
-        onClose={handleCloseConfirmModal}
+        isOpen={isOpen('deleteModal')}
+        onClose={handleCloseDeleteModal}
         onSave={handleDeleteConfirm}
         btnConfirm="삭제"
       >
         {selectedWorkoutId &&
           `'${getWorkoutName(selectedWorkoutId)}' 를(을) 삭제하겠습니까?`}
       </Modal>
+      <AddWorkOutModal
+        isOpen={isOpen('addModal')}
+        onClose={handleCloseAddModal}
+        onSave={() => handleSaveInput}
+        initialData={initialData}
+      />
     </Wrapper>
   );
 };

--- a/src/routes/Trainer/WorkOutManagement.tsx
+++ b/src/routes/Trainer/WorkOutManagement.tsx
@@ -36,7 +36,52 @@ const WorkOutManagement: React.FC = () => {
   const [selectedWorkoutId, setSelectedWorkoutId] = useState<number | null>(
     null
   );
-  const [initialData, setInitialData] = useState<WorkoutDataType | null>(null); // 수정
+  const [formState, setFormState] = useState({
+    name: '',
+    targetMuscle: '',
+    remark: '',
+    attributes: {
+      weight: false,
+      set: false,
+      rep: false,
+      time: false,
+      speed: false,
+    },
+  });
+
+  const initialAttributesState = {
+    weight: false,
+    set: false,
+    rep: false,
+    time: false,
+    speed: false,
+  };
+
+  const initialFormState = {
+    name: '',
+    targetMuscle: '',
+    remark: '',
+    attributes: initialAttributesState,
+  };
+
+  const initializeFormState = (data: WorkoutDataType | null) => {
+    if (data) {
+      setFormState({
+        name: data.name,
+        targetMuscle: data.target_muscle,
+        remark: data.remark,
+        attributes: {
+          weight: data.weight_input_required,
+          set: data.set_input_required,
+          rep: data.rep_input_required,
+          time: data.time_input_required,
+          speed: data.speed_input_required,
+        },
+      });
+    } else {
+      setFormState(initialFormState);
+    }
+  };
 
   // msw 데이터 불러오기
   useEffect(() => {
@@ -52,7 +97,9 @@ const WorkOutManagement: React.FC = () => {
     fetchWorkouts();
   }, []);
 
+  // 추가 버튼
   const handleOpenAddModal = () => {
+    initializeFormState(null);
     openModal('addModal');
   };
 
@@ -63,10 +110,11 @@ const WorkOutManagement: React.FC = () => {
 
   // 수정 버튼
   const handleOpenEditModal = (workout: WorkoutDataType) => {
-    setInitialData(workout);
+    initializeFormState(workout);
     openModal('addModal');
   };
 
+  // 삭제 버튼
   const handleOpenDeleteModal = (id: number) => {
     setSelectedWorkoutId(id);
     openModal('deleteModal');
@@ -78,8 +126,8 @@ const WorkOutManagement: React.FC = () => {
   };
 
   // TODO : 추가 적용
-  const handleSaveInput = (value?: string) => {
-    console.log(`Saved value: ${value}`);
+  const handleSaveInput = (workout: WorkoutDataType) => {
+    console.log(`Saved workout: ${workout}`);
     closeModal('addModal');
   };
 
@@ -127,8 +175,9 @@ const WorkOutManagement: React.FC = () => {
       <AddWorkOutModal
         isOpen={isOpen('addModal')}
         onClose={handleCloseAddModal}
-        onSave={() => handleSaveInput}
-        initialData={initialData}
+        onSave={handleSaveInput}
+        formState={formState}
+        setFormState={setFormState}
       />
     </Wrapper>
   );

--- a/src/styles/globalStyles.ts
+++ b/src/styles/globalStyles.ts
@@ -38,7 +38,7 @@ h1 {
 #root{
   margin: 0 auto;
   background-color: ${({ theme }) => theme.colors.white};
-  height: 100%;
+  min-height: 100%;
   position: relative;
   overflow-x: hidden;
 }

--- a/src/styles/globalStyles.ts
+++ b/src/styles/globalStyles.ts
@@ -38,7 +38,7 @@ h1 {
 #root{
   margin: 0 auto;
   background-color: ${({ theme }) => theme.colors.white};
-  min-height: 100%;
+  height: 100%;
   position: relative;
   overflow-x: hidden;
 }


### PR DESCRIPTION
### 📝 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
closed #30 

### ✨ 반영 브랜치
<!-- 어떤 브랜치에서 어떤 브랜치로 merge하는지 적어주세요 -->
- FROM: 30-feat/workout-add-drawer-refactor
- TO: `master`

### ✅ PR 내용
<!-- 기능마다 아래 템플릿으로 PR에 대한 설명을 적어주세요 (기능별 AS-IS, TO-BE, 변경이유 등) -->
- [x] Workout list 추가 모달 개발
> - Description: 새로운 Workout을 추가할 수 있는 모달을 개발했습니다. 모달은 운동명, 주요 자극 부위, 주의사항 노트, 그리고 속성 값을 입력 받을 수 있는 폼으로 구성되어 있습니다. 추가 버튼을 클릭하면 새로운 Workout 데이터를 입력할 수 있는 모달이 열리며, 입력된 데이터를 저장하여 리스트에 반영 할 예정입니다.

- [x] Workout list 수정 모달 개발
> - Description: 기존 Workout 데이터를 수정할 수 있는 모달을 개발했습니다. WorkOutManagement 컴포넌트에서 수정 버튼을 클릭하면 해당 Workout의 기존 데이터가 모달 폼에 미리 입력되어 표시됩니다. 사용자는 필요한 수정 작업을 수행한 후 저장할 수 있습니다. API 연동 시 수정된 데이터는 리스트에 즉시 반영 될 예정입니다.

- [x] Drawer 디자인 및 기능 추가
> - AS-IS: Drawer 디자인 및 확실한 기능 기획이 없었던 Drawer 디자인을 최소화 하여 빠른 작업을 우선 하여 메뉴 3개만 구성되어 있었음.
> - TO-BE: 간단한 디자인을 적용했고, Drawer가 아닌 부분을 클릭 시 Drawer가 닫히도록 구현하였고, Drawer가 열려있을 때는 스크롤을 할 수 없도록 구현했습니다. 스크롤을 강제로 한다고 해도 현재 Drawer height는 최대로 늘어져서 빈 곳이 없도록 구성했습니다.
> - Description: width값을 디자인을 위해 줄였고, Drawer를 누르는 사람들을 생각했을 때 편의성을 생각하기 위해 z-index를 우선하여 제일 상단에 배치하였고, 스크롤을 막았습니다.


### 🌐 테스트 배포
<!-- 모바일 기기에서 진행한 테스트에 대해 적어주세요 -->
- [x] 테스트 배포하여 잘 동작하는 지 확인했나요?
> - 테스트 배포 주소: https://test-training-diary.netlify.app/
> - 테스트 환경 (OS): Windows(Chrome / Firefox / Edge)
> - 테스트 환경 (Browser): ios (Safari)

### 📸 스크린샷
<!-- 가능하다면 스크린샷을 첨부해주세요 (Optional) -->
![test-training-diary netlify app_(iPhone 6_7_8)](https://github.com/user-attachments/assets/5d18c86c-8215-4ecf-a26c-05c36577c92f)


### 📌 ETC
<!-- 레퍼런스, 참고할 사항, 질문 사항이 있다면 적어주세요 (Optional) -->
정식 디자인을 두고 작업한 내용이 아니다 보니 디자인을 보고 아쉬운 부분이나 조금 변경되면 좋을 만한 부분은 말씀 해주시면 수정하도록 하겠습니다.

그리고, 한가지 더 컴포넌트 구조화를 어떻게 해야할지 조금 어려워서 현재 Trainer 폴더 구조로 담아뒀는데, 구조화 방법에 대해서 조언을 주시면 감사하겠습니다!😣
