### PR TITLE
[FEAT] Home > 식단관리 탭 > 식단 추가 버튼 및 모달 작업 #43

### DIFF
--- a/src/assets/icons/diet/addImg.svg
+++ b/src/assets/icons/diet/addImg.svg
@@ -1,0 +1,5 @@
+<svg width="18" height="16" viewBox="0 0 18 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect x="1" y="2" width="16" height="12" rx="1" stroke="#ADB5BD"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M10.5714 11.4286L7 7.5L2 13H9H12H16L12.5 9.5L10.5714 11.4286Z" fill="#BBBBBB"/>
+<circle cx="10.5" cy="6" r="1.5" fill="#BBBBBB"/>
+</svg>

--- a/src/components/Appointment/TraineeRegisterModal.tsx
+++ b/src/components/Appointment/TraineeRegisterModal.tsx
@@ -67,20 +67,20 @@ interface TraineeDataType {
   traineeName: string;
 }
 
-interface TraineeListProps {
+interface TraineeRegisterModalProps {
   items: TraineeDataType[];
   selectedTraineeId: number | null;
   onClick: (id: number) => void;
 }
 
-const TraineeList: React.FC<TraineeListProps> = ({
+const TraineeRegisterModal: React.FC<TraineeRegisterModalProps> = ({
   items,
   selectedTraineeId,
   onClick,
 }) => {
   return (
     <TraineeListWrapper>
-      {items.map((trainee) => (
+      {items.map(trainee => (
         <TraineeItem
           key={trainee.traineeId}
           $isSelected={trainee.traineeId === selectedTraineeId}
@@ -99,4 +99,4 @@ const TraineeList: React.FC<TraineeListProps> = ({
   );
 };
 
-export default TraineeList;
+export default TraineeRegisterModal;

--- a/src/components/Common/AddButton.tsx
+++ b/src/components/Common/AddButton.tsx
@@ -10,9 +10,9 @@ export const AddButton = styled.button`
   opacity: 0.8;
   line-height: 1;
 
-  position: sticky;
+  position: fixed;
   bottom: 80px;
-  right: 30px;
+  right: calc(50% - 225px + 30px);
   margin-left: auto;
 
   &:active {
@@ -22,5 +22,9 @@ export const AddButton = styled.button`
 
   &:hover {
     opacity: 1;
+  }
+
+  @media (max-width: 450px) {
+    right: 30px;
   }
 `;

--- a/src/components/Common/AddButton.tsx
+++ b/src/components/Common/AddButton.tsx
@@ -24,7 +24,8 @@ export const AddButton = styled.button`
     opacity: 1;
   }
 
-  @media (max-width: 450px) {
+  @media ${({ theme }) => theme.media.tablet},
+    ${({ theme }) => theme.media.mobile} {
     right: 30px;
   }
 `;

--- a/src/components/Common/AddButton.tsx
+++ b/src/components/Common/AddButton.tsx
@@ -17,12 +17,7 @@ export const AddButton = styled.button`
   right: calc(50% - 225px + 30px);
   margin-left: auto;
   box-shadow: 0 4px 4px ${({ theme }) => hexToRgba(theme.colors.black, 0.35)};
-  display: block;
   z-index: 99;
-
-  @media (max-width: 450px) {
-    position: fixed;
-  }
 
   &:active {
     background-color: ${({ theme }) => theme.colors.main600};

--- a/src/components/Common/Modal/Modal.tsx
+++ b/src/components/Common/Modal/Modal.tsx
@@ -89,8 +89,6 @@ const ModalCustomWrapper = styled.div`
   flex-direction: column;
   gap: 10px;
   font-size: 1.4rem;
-  color: ${({ theme }) => theme.colors.red300};
-  text-align: right;
 `;
 
 const ButtonGroup = styled.div`
@@ -149,7 +147,7 @@ const Modal: React.FC<ModalProps> = ({
               type="text"
               value={inputValue}
               placeholder={typeof children === 'string' ? children : undefined}
-              onChange={(e) => setInputValue(e.target.value)}
+              onChange={e => setInputValue(e.target.value)}
             />
             <ErrorMessage>ErrorMessage</ErrorMessage>
           </ModalInputWrapper>

--- a/src/components/Common/Modal/Modal.tsx
+++ b/src/components/Common/Modal/Modal.tsx
@@ -89,6 +89,7 @@ const ModalCustomWrapper = styled.div`
   flex-direction: column;
   gap: 10px;
   font-size: 1.4rem;
+  color: ${({ theme }) => theme.colors.gray900};
 `;
 
 const ButtonGroup = styled.div`

--- a/src/components/Common/Navigation/Navigation.tsx
+++ b/src/components/Common/Navigation/Navigation.tsx
@@ -37,7 +37,6 @@ const NavItem = styled.div<{ $isActive?: boolean }>`
   align-items: center;
   width: 100%;
   transition: background-color 0.3s;
-  pointer-events: ${({ $isActive }) => ($isActive ? 'none' : 'auto')};
 
   a {
     display: flex;

--- a/src/components/Trainee/DietUploadModal.tsx
+++ b/src/components/Trainee/DietUploadModal.tsx
@@ -1,0 +1,173 @@
+import React, { useEffect, useState } from 'react';
+import styled from 'styled-components';
+import { useForm } from 'react-hook-form';
+
+import addImg from '@icons/diet/addImg.svg';
+
+const Form = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 15px;
+`;
+
+const Label = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+`;
+
+const FileInputWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 15px;
+`;
+
+const Input = styled.input`
+  display: none;
+`;
+
+const CustomFileLabel = styled.label`
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  width: fit-content;
+  padding: 5px 10px;
+  border: 1px solid ${({ theme }) => theme.colors.gray400};
+  border-radius: 5px;
+  color: ${({ theme }) => theme.colors.gray500};
+  font-family: 'NanumSquareExtraBold';
+  font-size: 1.6rem;
+  cursor: pointer;
+
+  &:active {
+    background-color: ${({ theme }) => theme.colors.gray200};
+  }
+`;
+
+const PreviewWrapper = styled.div`
+  width: 36px;
+  height: 36px;
+  cursor: pointer;
+`;
+
+const Preview = styled.img`
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+`;
+
+const Message = styled.span`
+  color: ${({ theme }) => theme.colors.gray600};
+  font-size: 1.2rem;
+`;
+
+const TextArea = styled.textarea`
+  padding: 10px 16px;
+  border: 1px solid ${({ theme }) => theme.colors.gray400};
+  border-radius: 8px;
+  outline: none;
+  width: 100%;
+  height: 92px;
+  line-height: 1.5;
+  color: ${({ theme }) => theme.colors.gray900};
+  font-size: 1.6rem;
+  font-family:
+    'NanumSquare',
+    'NotoSans KR',
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    'Segoe UI',
+    Roboto,
+    Oxygen,
+    Ubuntu,
+    Cantarell,
+    'Open Sans',
+    'Helvetica Neue',
+    sans-serif;
+  resize: none;
+`;
+
+interface FormData {
+  photo: FileList | null;
+  content: string;
+}
+
+interface DietUploadModalProps {
+  onChangeFormData: (data: FormData) => void;
+  formData: FormData;
+}
+
+const DietUploadModal: React.FC<DietUploadModalProps> = ({
+  onChangeFormData,
+  formData,
+}) => {
+  const { register, watch, setValue, reset } = useForm<FormData>({
+    defaultValues: formData,
+  });
+  const [preview, setPreview] = useState<string | null>(null);
+  const [photoMessage, setPhotoMessage] = useState<string | null>(
+    '사진을 등록해주세요'
+  );
+
+  const photo = watch('photo');
+  const content = watch('content');
+
+  const onRemoveImage = () => {
+    setValue('photo', null);
+    setPreview(null);
+    setPhotoMessage('사진을 등록해주세요');
+  };
+
+  useEffect(() => {
+    onChangeFormData({ photo, content });
+
+    if (photo && photo.length > 0) {
+      const file = photo[0];
+      const previewUrl = URL.createObjectURL(file);
+      setPreview(previewUrl);
+      setPhotoMessage(null);
+
+      return () => URL.revokeObjectURL(previewUrl);
+    } else {
+      setPreview(null);
+      setPhotoMessage('사진을 등록해주세요');
+    }
+  }, [photo, content]);
+
+  useEffect(() => {
+    reset(formData);
+  }, [formData]);
+
+  return (
+    <Form>
+      <Label>
+        <span>사진첨부 :</span>
+        <FileInputWrapper>
+          <Input
+            type="file"
+            id="photo"
+            accept="image/*"
+            {...register('photo')}
+          />
+          <CustomFileLabel htmlFor="photo">
+            <img src={addImg} alt="upload image" />
+            <span>사진 선택</span>
+          </CustomFileLabel>
+          {preview && (
+            <PreviewWrapper onClick={onRemoveImage}>
+              <Preview src={preview} alt="preview" />
+            </PreviewWrapper>
+          )}{' '}
+          <Message>{photoMessage}</Message>
+        </FileInputWrapper>
+      </Label>
+      <Label>
+        <span>내용 :</span>
+        <TextArea {...register('content')} />
+      </Label>
+    </Form>
+  );
+};
+
+export default DietUploadModal;

--- a/src/components/Trainee/DietUploadModal.tsx
+++ b/src/components/Trainee/DietUploadModal.tsx
@@ -118,8 +118,6 @@ const DietUploadModal: React.FC<DietUploadModalProps> = ({
       setFormData({ ...formData, photo: files });
       const previewUrl = URL.createObjectURL(file);
       setPreview(previewUrl);
-
-      return () => URL.revokeObjectURL(previewUrl);
     }
 
     if (e.target instanceof HTMLTextAreaElement) {

--- a/src/pages/Appointment/MonthlyContent.tsx
+++ b/src/pages/Appointment/MonthlyContent.tsx
@@ -5,14 +5,14 @@ import { format } from 'date-fns';
 
 import Alert from '@components/Common/Alert/Alert';
 import Modal from '@components/Common/Modal/Modal';
+import { SectionWrapper } from '@components/Common/SectionWrapper';
 import MonthlyCalendar from '@components/Appointment/MonthlyCalendar';
 import ButtonContainer from '@components/Appointment/ButtonContainer';
 import TimeTableContainer from '@components/Appointment/TimeTableContainer';
-import TraineeList from '@components/Appointment/TraineeList';
+import TraineeRegisterModal from '@components/Appointment/TraineeRegisterModal';
 import useSchedules from 'src/hooks/useSchedules';
 import useModals from 'src/hooks/useModals';
 import { traineeList } from 'src/mocks/data/traineeList';
-import { SectionWrapper } from '@components/Common/SectionWrapper';
 
 const Wrapper = styled.div`
   display: flex;
@@ -43,6 +43,11 @@ const CompleteButton = styled.button`
   &:active {
     background-color: ${({ theme }) => theme.colors.gray900};
   }
+`;
+
+const TraineeRegisterModalText = styled.span`
+  color: ${({ theme }) => theme.colors.red300};
+  text-align: right;
 `;
 
 const MonthlyContent: React.FC = () => {
@@ -187,12 +192,14 @@ const MonthlyContent: React.FC = () => {
           onSave={() => onSaveModal('registerModal')}
           btnConfirm="저장"
         >
-          <TraineeList
+          <TraineeRegisterModal
             items={traineeList}
             selectedTraineeId={selectedTraineeId}
             onClick={onClickTrainee}
           />
-          저장 시 바로 적용됩니다.
+          <TraineeRegisterModalText>
+            저장 시 바로 적용됩니다.
+          </TraineeRegisterModalText>
         </Modal>
       </Wrapper>
     </SectionWrapper>

--- a/src/pages/Trainee/Diet.tsx
+++ b/src/pages/Trainee/Diet.tsx
@@ -5,6 +5,10 @@ import InfiniteScroll from 'react-infinite-scroll-component';
 
 import addBtn from '@icons/home/addbtn.svg';
 import { AddButton } from '@components/Common/AddButton';
+import Modal from '@components/Common/Modal/Modal';
+import Alert from '@components/Common/Alert/Alert';
+import DietUploadModal from '@components/Trainee/DietUploadModal';
+import useModals from 'src/hooks/useModals';
 
 const Wrapper = styled.div`
   height: calc(100vh - 150px);
@@ -45,8 +49,14 @@ const getMoreImages = (count = 9) => {
 const Diet: React.FC = () => {
   const navigate = useNavigate();
   const { traineeId } = useParams<{ traineeId: string }>();
+  const { openModal, closeModal, isOpen } = useModals();
   const [images, setImages] = useState<string[]>([]);
+  const [formData, setFormData] = useState<{
+    photo: FileList | null;
+    content: string;
+  }>({ photo: null, content: '' });
   const [isLoading, setLoading] = useState<boolean>(false);
+  const [errorAlert, setErrorAlert] = useState<string>('');
 
   const fetchMoreImages = async () => {
     if (isLoading) return;
@@ -59,6 +69,34 @@ const Diet: React.FC = () => {
   const onClickDiet = (dietId: number) => {
     navigate(`/trainee/${traineeId}/diet/${dietId}`);
   };
+
+  const onClickAddButton = () => {
+    setFormData({ photo: null, content: '' });
+    openModal('addModal');
+  };
+
+  const onSaveAddModal = () => {
+    if (!formData.photo) {
+      return setErrorAlert('식단 사진을 추가해주세요.');
+    }
+
+    if (!formData.content) {
+      return setErrorAlert('식단 내용을 입력해주세요.');
+    }
+
+    // 식단 추가 API 요청 단계 추가
+    console.log(formData);
+
+    closeModal('addModal');
+  };
+
+  const onChangeFormData = (
+    data: React.SetStateAction<{ photo: FileList | null; content: string }>
+  ) => {
+    setFormData(data);
+  };
+
+  const onCloseErrorAlert = () => setErrorAlert('');
 
   useEffect(() => setImages(getMoreImages(24)), []);
 
@@ -79,9 +117,25 @@ const Diet: React.FC = () => {
           ))}
         </Gallery>
       </InfiniteScroll>
-      <AddButton>
+      <AddButton onClick={onClickAddButton}>
         <img src={addBtn} alt="add button" />
       </AddButton>
+      <Modal
+        title="식단 올리기"
+        type="custom"
+        isOpen={isOpen('addModal')}
+        onClose={() => closeModal('addModal')}
+        onSave={() => onSaveAddModal()}
+        btnConfirm="등록"
+      >
+        <DietUploadModal
+          onChangeFormData={onChangeFormData}
+          formData={formData}
+        />
+      </Modal>
+      {errorAlert && (
+        <Alert $type="error" text={errorAlert} onClose={onCloseErrorAlert} />
+      )}
     </Wrapper>
   );
 };

--- a/src/pages/Trainee/Diet.tsx
+++ b/src/pages/Trainee/Diet.tsx
@@ -55,6 +55,7 @@ const Diet: React.FC = () => {
     photo: FileList | null;
     content: string;
   }>({ photo: null, content: '' });
+  const [preview, setPreview] = useState<string | null>(null);
   const [isLoading, setLoading] = useState<boolean>(false);
   const [errorAlert, setErrorAlert] = useState<string>('');
 
@@ -72,6 +73,7 @@ const Diet: React.FC = () => {
 
   const onClickAddButton = () => {
     setFormData({ photo: null, content: '' });
+    setPreview(null);
     openModal('addModal');
   };
 
@@ -88,12 +90,6 @@ const Diet: React.FC = () => {
     console.log(formData);
 
     closeModal('addModal');
-  };
-
-  const onChangeFormData = (
-    data: React.SetStateAction<{ photo: FileList | null; content: string }>
-  ) => {
-    setFormData(data);
   };
 
   const onCloseErrorAlert = () => setErrorAlert('');
@@ -129,8 +125,10 @@ const Diet: React.FC = () => {
         btnConfirm="등록"
       >
         <DietUploadModal
-          onChangeFormData={onChangeFormData}
           formData={formData}
+          setFormData={setFormData}
+          preview={preview}
+          setPreview={setPreview}
         />
       </Modal>
       {errorAlert && (

--- a/src/pages/Trainee/Diet.tsx
+++ b/src/pages/Trainee/Diet.tsx
@@ -3,8 +3,11 @@ import { useNavigate, useParams } from 'react-router-dom';
 import styled from 'styled-components';
 import InfiniteScroll from 'react-infinite-scroll-component';
 
+import addBtn from '@icons/home/addbtn.svg';
+import { AddButton } from '@components/Common/AddButton';
+
 const Wrapper = styled.div`
-  height: 100vh;
+  height: calc(100vh - 150px);
   overflow: auto;
 `;
 
@@ -71,11 +74,14 @@ const Diet: React.FC = () => {
         <Gallery>
           {images.map((src, index) => (
             <ImageWrapper key={index} onClick={() => onClickDiet(index)}>
-              <Image src={src} alt={`image ${index}`} />
+              <Image src={src} alt={`image ${index}`} loading="lazy" />
             </ImageWrapper>
           ))}
         </Gallery>
       </InfiniteScroll>
+      <AddButton>
+        <img src={addBtn} alt="add button" />
+      </AddButton>
     </Wrapper>
   );
 };


### PR DESCRIPTION
### 📝 관련 이슈
closed #43 

### ✨ 반영 브랜치
- FROM: `43-feat/add-diet`
- TO: `master`

### ✅ PR 내용
- [x] 식단관리 탭 > 식단 추가 모달 작업
> - 식단관리 탭에 addButton 추가
> - addButton 클릭 시 식단 추가 모달 작업
> - 이미지 업로드 기능 및 미리보기 기능, 미리보기 클릭시 이미지 제거 기능 추가
> - 모달 폼에서 필수 값 미입력 시 errorAlert 추가

- [x] 식단관리 탭 이미지 `lazy-loading` 적용
> - `img` 태그의 `loading: lazy` 속성 추가하여 사용자가 실제로 이미지를 보기 전까지 지연 로딩
> - 자세한 설명은 ETC 참고

- [x] 공통 컴포넌트인 `addButton` 위치 고정
> - AS-IS: 데스크탑으로 볼 때는 버튼의 `position: sticky` 속성 때문에 컨텐츠의 길이에 따라 버튼의 위치가 바뀜
> - TO-BE: 버튼의 속성 `position: fixed`로 수정한 뒤 `media-qeury`로 뷰포트 크기에 따라 버튼 위치 지정
> - Description: 데스크탑에서는 `right: calc(50% - 225px + 30px);` 설정하여 뷰포트에 따라 버튼이 유동적으로 움직이도록 수정했고, 450px 이하 모바일 기기에서는 `right: 30px;` 설정

- [x] 공통 컴포넌트인 `Modal` 커스텀 타입 css 수정
> - AS-IS: 폰트 정렬이 `right`, 폰트 색상 `red` 적용
> - TO-BE: 폰트 정렬 속성은 제거하고, 폰트 색상은 기본 색상인 `gray900` 설정
> - Description: 커스텀 모달을 사용하는 곳에서 필요하다면 확장해서 사용

### 🌐 테스트 배포
- [x] 테스트 배포하여 잘 동작하는 지 확인했나요?
> - 테스트 배포 주소: https://sumin-test-training-diary.netlify.app/trainee/1/diet
> - 테스트 환경 (Desktop): MacOS (Chrome / Safari / Firefox / Edge)
> - 테스트 환경 (Mobile): Android (Chrome / 삼성인터넷)

### 📸 스크린샷
![식단 추가 모달.gif](https://github.com/user-attachments/assets/ba45a7c4-688e-4e91-89e5-3f92fd4bad1a)

### 📌 ETC
- 이미지 로딩 시에 `lazy loading`을 직접 구현할 수도 있지만, HTML5에서는 `img` 태그에 `loading` 속성을 사용하여 브라우저에서 이미지의 로딩 방식을 제어할 수 있습니다. 그 중 `loading: 'lazy'` 속성은 이미지를 사용자가 스크롤하여 볼 때까지 이미지를 로드하지 않으므로 페이지 로딩 속도와 성능을 향상시킵니다! 
- Can I use에서 `lazy loading` 브라우저별 호환성에 대해 찾아보면 인터넷 익스플로러를 제외한 모든 브라우저에서 지원하고 있고, 글로벌 사용량은 93%를 넘기 때문에, `lazy loading`을 html 속성으로 적용하는 방법을 선택했습니다 ([Can I use 참고](https://caniuse.com/?search=Loading))
- 이미지를 사용하는 곳에서는 `loading: 'lazy'` 를 적용해주세요! 🙇‍♂️
