### PR TITLE
[FEAT] API 연동 전 SETTING #55

### DIFF
--- a/public/firebase-messaging-sw.js
+++ b/public/firebase-messaging-sw.js
@@ -1,8 +1,13 @@
-// Scripts for firebase and firebase messaging
-importScripts('https://www.gstatic.com/firebasejs/8.10.0/firebase-app.js');
 importScripts(
-  'https://www.gstatic.com/firebasejs/8.10.0/firebase-messaging.js'
+  'https://www.gstatic.com/firebasejs/10.8.0/firebase-app-compat.js'
 );
+importScripts(
+  'https://www.gstatic.com/firebasejs/10.8.0/firebase-messaging-compat.js'
+);
+
+self.addEventListener('install', e => {
+  self.skipWaiting();
+});
 
 const firebaseConfig = {
   apiKey: 'AIzaSyAxLUWYFvRn67L9yLk2TnMDO6VUkXKXSKk',
@@ -16,7 +21,6 @@ const firebaseConfig = {
 
 firebase.initializeApp(firebaseConfig);
 
-// Retrieve firebase messaging
 const messaging = firebase.messaging();
 
 messaging.onBackgroundMessage(payload => {
@@ -24,7 +28,7 @@ messaging.onBackgroundMessage(payload => {
   const notificationTitle = payload.notification.title;
   const notificationOptions = {
     body: payload.notification.body,
-    image: payload.notification.image,
+    icon: payload.notification.image,
   };
 
   self.registration.showNotification(notificationTitle, notificationOptions);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,17 +1,19 @@
 import { useEffect } from 'react';
 import { ThemeProvider } from 'styled-components';
-import { onMessage } from 'firebase/messaging';
+import { getMessaging, onMessage } from 'firebase/messaging';
 import { ToastContainer, toast } from 'react-toastify';
 import 'react-toastify/dist/ReactToastify.css';
 
-import { messaging } from './firebase/firebaseConfig';
 import AppRoutes from './routes';
 import GlobalStyles from './styles/globalStyles';
 import theme from './styles/theme';
 import PushMessage from '@components/Common/PushMessage';
+import { app } from './firebase/initFirebase';
 
 function App() {
   useEffect(() => {
+    const messaging = getMessaging(app);
+
     onMessage(messaging, payload => {
       if (payload.notification) {
         toast(<PushMessage notification={payload.notification} />);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,7 +13,6 @@ import PushMessage from '@components/Common/PushMessage';
 function App() {
   useEffect(() => {
     onMessage(messaging, payload => {
-      console.log('Message received. ', payload);
       if (payload.notification) {
         toast(<PushMessage notification={payload.notification} />);
       }

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -1,0 +1,35 @@
+import { NavigateFunction } from 'react-router-dom';
+
+import { axiosInstance, createInterceptor } from './axiosInstance';
+import useUserStore, { User } from 'src/stores/userStore';
+
+const AuthApi = (navigate: NavigateFunction) => {
+  createInterceptor(navigate);
+
+  const { setUser } = useUserStore.getState();
+
+  return {
+    login: (email: string, password: string) =>
+      axiosInstance.post('/users/sign-in', { email, password }),
+
+    getUser: async () => {
+      try {
+        const response = await axiosInstance.get('/users/info');
+        const userData = response.data;
+        const user: User = {
+          id: userData.id,
+          role: userData.role,
+          unreadNotification: userData.unreadNotification,
+        };
+
+        setUser(user);
+        return user;
+      } catch (error) {
+        console.error('유저 정보 조회 실패: ', error);
+        throw error;
+      }
+    },
+  };
+};
+
+export default AuthApi;

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -1,35 +1,16 @@
 import { NavigateFunction } from 'react-router-dom';
 
 import { axiosInstance, createInterceptor } from './axiosInstance';
-import useUserStore, { User } from 'src/stores/userStore';
 
-const AuthApi = (navigate: NavigateFunction) => {
+const CreateAuthApi = (navigate: NavigateFunction) => {
   createInterceptor(navigate);
-
-  const { setUser } = useUserStore.getState();
 
   return {
     login: (email: string, password: string) =>
       axiosInstance.post('/users/sign-in', { email, password }),
 
-    getUser: async () => {
-      try {
-        const response = await axiosInstance.get('/users/info');
-        const userData = response.data;
-        const user: User = {
-          id: userData.id,
-          role: userData.role,
-          unreadNotification: userData.unreadNotification,
-        };
-
-        setUser(user);
-        return user;
-      } catch (error) {
-        console.error('유저 정보 조회 실패: ', error);
-        throw error;
-      }
-    },
+    getUser: () => axiosInstance.get('/users/info'),
   };
 };
 
-export default AuthApi;
+export default CreateAuthApi;

--- a/src/api/axiosInstance.ts
+++ b/src/api/axiosInstance.ts
@@ -1,9 +1,11 @@
 import axios, { AxiosError, AxiosResponse } from 'axios';
 import { NavigateFunction } from 'react-router-dom';
 
+import useUserStore from 'src/stores/userStore';
+
 const axiosInstance = axios.create({
   baseURL: 'https://api.training-diary.co.kr/api',
-  withCredentials: true, //필요한 경우 사용 (클라이언트 로컬에서는 주석처리해야 쿠키 받아옴)
+  withCredentials: true,
 });
 
 const createInterceptor = (navigate: NavigateFunction): void => {
@@ -11,6 +13,9 @@ const createInterceptor = (navigate: NavigateFunction): void => {
     (response: AxiosResponse) => response,
     (error: AxiosError) => {
       if (error.response?.status === 401) {
+        const setUser = useUserStore.getState().setUser;
+        setUser(null);
+
         navigate('/login');
       } else if (error.response?.status === 404) {
         navigate('/not-found');

--- a/src/api/axiosInstance.ts
+++ b/src/api/axiosInstance.ts
@@ -1,0 +1,23 @@
+import axios, { AxiosError, AxiosResponse } from 'axios';
+import { NavigateFunction } from 'react-router-dom';
+
+const axiosInstance = axios.create({
+  baseURL: 'https://api.training-diary.co.kr/api',
+  withCredentials: true, //필요한 경우 사용 (클라이언트 로컬에서는 주석처리해야 쿠키 받아옴)
+});
+
+const createInterceptor = (navigate: NavigateFunction): void => {
+  axiosInstance.interceptors.response.use(
+    (response: AxiosResponse) => response,
+    (error: AxiosError) => {
+      if (error.response?.status === 401) {
+        navigate('/login');
+      } else if (error.response?.status === 404) {
+        navigate('/not-found');
+      }
+      return Promise.reject(error);
+    }
+  );
+};
+
+export { axiosInstance, createInterceptor };

--- a/src/components/Common/Header/Header.tsx
+++ b/src/components/Common/Header/Header.tsx
@@ -7,7 +7,7 @@ import bellIcon from '@icons/header/bell.svg';
 import hamBtnIcon from '@icons/header/hamBtn.svg';
 import Drawer from './Drawer';
 import { hexToRgba } from 'src/utils/hexToRgba';
-import { user } from 'src/stores/userStore';
+import useUserStore from 'src/stores/userStore';
 
 const HeaderWrapper = styled.header`
   display: flex;
@@ -58,6 +58,7 @@ const BackIcon = styled.div`
 const Header: React.FC = () => {
   const location = useLocation();
   const navigate = useNavigate();
+  const user = useUserStore(state => state.user);
   const [isDrawerOpen, setDrawerOpen] = useState(false);
 
   const toggleDrawer = () => {

--- a/src/firebase/initFirebase.ts
+++ b/src/firebase/initFirebase.ts
@@ -1,5 +1,4 @@
 import { initializeApp } from 'firebase/app';
-import { getMessaging } from 'firebase/messaging';
 
 //Firebase Config values imported from .env file
 const firebaseConfig = {
@@ -13,7 +12,4 @@ const firebaseConfig = {
 };
 
 // Initialize Firebase
-const app = initializeApp(firebaseConfig);
-
-// Messaging service
-export const messaging = getMessaging(app);
+export const app = initializeApp(firebaseConfig);

--- a/src/firebase/notificationPermission.ts
+++ b/src/firebase/notificationPermission.ts
@@ -1,17 +1,14 @@
-import { getToken } from 'firebase/messaging';
-
-import { messaging } from 'src/firebase/firebaseConfig';
+import { getMessaging, getToken } from 'firebase/messaging';
+import { app } from 'src/firebase/initFirebase';
 
 const requestPermission = async () => {
   try {
-    const { VITE_APP_VAPID_KEY } = import.meta.env;
-
-    // Requesting permission using Notification API
     const permission = await Notification.requestPermission();
+    const messaging = getMessaging(app);
 
     if (permission === 'granted') {
       const token = await getToken(messaging, {
-        vapidKey: VITE_APP_VAPID_KEY,
+        vapidKey: import.meta.env.VITE_APP_VAPID_KEY,
       });
 
       if (token) {

--- a/src/firebase/registerServiceWorker.ts
+++ b/src/firebase/registerServiceWorker.ts
@@ -1,0 +1,21 @@
+const registerServiceWorker = () => {
+  if ('serviceWorker' in navigator) {
+    window.addEventListener('load', function () {
+      navigator.serviceWorker
+        .register('/firebase-messaging-sw.js', {
+          scope: '/firebase-cloud-messaging-push-scope',
+        })
+        .then(function (registration) {
+          console.log(
+            'Service Worker가 scope에 등록되었습니다.:',
+            registration.scope
+          );
+        })
+        .catch(function (err) {
+          console.log('Service Worker 등록 실패:', err);
+        });
+    });
+  }
+};
+
+export default registerServiceWorker;

--- a/src/hooks/useFetchUser.ts
+++ b/src/hooks/useFetchUser.ts
@@ -1,0 +1,33 @@
+import { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+import useUserStore, { User } from 'src/stores/userStore';
+import CreateAuthApi from 'src/api/auth';
+
+const useFetchUser = () => {
+  const navigate = useNavigate();
+  const setUser = useUserStore(state => state.setUser);
+  const AuthApi = CreateAuthApi(navigate);
+
+  useEffect(() => {
+    const fetchUser = async () => {
+      try {
+        const response = await AuthApi.getUser();
+        const userData = response.data;
+        const user: User = {
+          id: userData.id,
+          role: userData.role,
+          unreadNotification: userData.unreadNotification,
+        };
+
+        setUser(user);
+      } catch (error) {
+        throw error;
+      }
+    };
+
+    fetchUser();
+  }, []);
+};
+
+export default useFetchUser;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -15,10 +15,38 @@ async function enableMocking() {
   return worker.start();
 }
 
-enableMocking().then(() => {
-  ReactDOM.createRoot(document.getElementById('root')!).render(
-    <React.StrictMode>
-      <App />
-    </React.StrictMode>
-  );
-});
+// enableMocking().then(() => {
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);
+// });
+
+// Service Worker 등록
+if ('serviceWorker' in navigator) {
+  navigator.serviceWorker
+    .getRegistrations()
+    .then(registrations => {
+      for (let registration of registrations) {
+        registration.unregister();
+      }
+    })
+    .catch(error => {
+      console.error('Service Worker unregistration failed:', error);
+    });
+
+  window.addEventListener('load', () => {
+    navigator.serviceWorker
+      .register('/firebase-messaging-sw.js')
+      .then(registration => {
+        console.log(
+          'Service Worker registered with scope:',
+          registration.scope
+        );
+      })
+      .catch(error => {
+        console.error('Service Worker registration failed:', error);
+      });
+  });
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,16 +4,16 @@ import ReactDOM from 'react-dom/client';
 import App from './App.tsx';
 
 // enableMocking 함수 정의
-async function enableMocking() {
-  // if (process.env.NODE_ENV !== 'development') {
-  //   return;
-  // }
+// async function enableMocking() {
+//   // if (process.env.NODE_ENV !== 'development') {
+//   //   return;
+//   // }
 
-  const { worker } = await import('./mocks/browser');
+//   const { worker } = await import('./mocks/browser');
 
-  // `worker.start()`는 Service Worker가 요청을 가로채기 위해 준비될 때까지 대기합니다.
-  return worker.start();
-}
+//   // `worker.start()`는 Service Worker가 요청을 가로채기 위해 준비될 때까지 대기합니다.
+//   return worker.start();
+// }
 
 // enableMocking().then(() => {
 ReactDOM.createRoot(document.getElementById('root')!).render(

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,51 +2,25 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 
 import App from './App.tsx';
+import registerServiceWorker from './firebase/registerServiceWorker.ts';
 
 // enableMocking 함수 정의
-// async function enableMocking() {
-//   // if (process.env.NODE_ENV !== 'development') {
-//   //   return;
-//   // }
+async function enableMocking() {
+  // if (process.env.NODE_ENV !== 'development') {
+  //   return;
+  // }
 
-//   const { worker } = await import('./mocks/browser');
+  const { worker } = await import('./mocks/browser');
 
-//   // `worker.start()`는 Service Worker가 요청을 가로채기 위해 준비될 때까지 대기합니다.
-//   return worker.start();
-// }
-
-// enableMocking().then(() => {
-ReactDOM.createRoot(document.getElementById('root')!).render(
-  <React.StrictMode>
-    <App />
-  </React.StrictMode>
-);
-// });
-
-// Service Worker 등록
-if ('serviceWorker' in navigator) {
-  navigator.serviceWorker
-    .getRegistrations()
-    .then(registrations => {
-      for (let registration of registrations) {
-        registration.unregister();
-      }
-    })
-    .catch(error => {
-      console.error('Service Worker unregistration failed:', error);
-    });
-
-  window.addEventListener('load', () => {
-    navigator.serviceWorker
-      .register('/firebase-messaging-sw.js')
-      .then(registration => {
-        console.log(
-          'Service Worker registered with scope:',
-          registration.scope
-        );
-      })
-      .catch(error => {
-        console.error('Service Worker registration failed:', error);
-      });
-  });
+  // `worker.start()`는 Service Worker가 요청을 가로채기 위해 준비될 때까지 대기합니다.
+  return worker.start();
 }
+
+registerServiceWorker();
+enableMocking().then(() => {
+  ReactDOM.createRoot(document.getElementById('root')!).render(
+    <React.StrictMode>
+      <App />
+    </React.StrictMode>
+  );
+});

--- a/src/pages/Login/Login.tsx
+++ b/src/pages/Login/Login.tsx
@@ -1,6 +1,8 @@
 import React, { useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 
+import emailIcon from '@icons/auth/email.svg';
+import passwordIcon from '@icons/auth/password.svg';
 import Button from '@components/Common/Button/Button';
 import Alert from '@components/Common/Alert/Alert';
 import AuthSwitcher from '@components/Auth/AuthSwitcher';
@@ -10,8 +12,8 @@ import AuthInputBox from '@components/Auth/AuthInputBox/AuthInputBox';
 import { AuthWrapper } from '@components/Auth/styledComponents/AuthWrapper';
 import { AuthContainer } from '@components/Auth/styledComponents/AuthContainer';
 import { AuthForm } from '@components/Auth/styledComponents/AuthForm';
-import emailIcon from '@icons/auth/email.svg';
-import passwordIcon from '@icons/auth/password.svg';
+import requestPermission from './loginService';
+import CreateAuthApi from 'src/api/auth';
 
 interface FormState {
   email: string;
@@ -20,6 +22,7 @@ interface FormState {
 
 const Login: React.FC = () => {
   const navigate = useNavigate();
+  const AuthApi = CreateAuthApi(navigate);
 
   const [isLoading, setLoading] = useState<boolean>(false);
   const [formState, setFormState] = useState<FormState>({
@@ -32,14 +35,14 @@ const Login: React.FC = () => {
   const onChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value } = event.target;
 
-    setFormState((prev) => ({
+    setFormState(prev => ({
       ...prev,
       [name]: value,
     }));
   };
 
   const onToggleShowPassword = () => {
-    setShowPassword((prev) => !prev);
+    setShowPassword(prev => !prev);
   };
 
   const onSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
@@ -61,11 +64,14 @@ const Login: React.FC = () => {
     try {
       setLoading(true);
 
-      // 로그인 API 요청 단계 추가
+      await AuthApi.login(email, password);
 
-      navigate('/');
+      await requestPermission();
+
+      await AuthApi.getUser();
     } catch (error) {
       setErrorAlert('이메일과 비밀번호를 확인해주세요.');
+      console.log(error);
     } finally {
       setLoading(false);
     }

--- a/src/pages/Login/Login.tsx
+++ b/src/pages/Login/Login.tsx
@@ -12,7 +12,7 @@ import AuthInputBox from '@components/Auth/AuthInputBox/AuthInputBox';
 import { AuthWrapper } from '@components/Auth/styledComponents/AuthWrapper';
 import { AuthContainer } from '@components/Auth/styledComponents/AuthContainer';
 import { AuthForm } from '@components/Auth/styledComponents/AuthForm';
-import requestPermission from './loginService';
+import requestPermission from '../../firebase/notificationPermission';
 import CreateAuthApi from 'src/api/auth';
 
 interface FormState {
@@ -71,7 +71,7 @@ const Login: React.FC = () => {
       await AuthApi.getUser();
     } catch (error) {
       setErrorAlert('이메일과 비밀번호를 확인해주세요.');
-      console.log(error);
+      console.error('로그인 에러: ', error);
     } finally {
       setLoading(false);
     }

--- a/src/pages/Login/Login.tsx
+++ b/src/pages/Login/Login.tsx
@@ -14,6 +14,7 @@ import { AuthContainer } from '@components/Auth/styledComponents/AuthContainer';
 import { AuthForm } from '@components/Auth/styledComponents/AuthForm';
 import requestPermission from '../../firebase/notificationPermission';
 import CreateAuthApi from 'src/api/auth';
+import useFetchUser from 'src/hooks/useFetchUser';
 
 interface FormState {
   email: string;
@@ -67,13 +68,12 @@ const Login: React.FC = () => {
       await AuthApi.login(email, password);
 
       await requestPermission();
-
-      await AuthApi.getUser();
     } catch (error) {
       setErrorAlert('이메일과 비밀번호를 확인해주세요.');
       console.error('로그인 에러: ', error);
     } finally {
       setLoading(false);
+      useFetchUser(); // 로그인 API response 변경 후 로직 수정
     }
   };
 

--- a/src/pages/Login/loginService.ts
+++ b/src/pages/Login/loginService.ts
@@ -1,5 +1,4 @@
 import { getToken } from 'firebase/messaging';
-import { toast } from 'react-toastify';
 
 import { messaging } from 'src/firebase/firebaseConfig';
 
@@ -18,15 +17,10 @@ const requestPermission = async () => {
       if (token) {
         // We can send token to server
         console.log('Token generated : ', token);
-        toast.success('Notification permission granted. Token generated.');
       }
-    } else if (permission === 'denied') {
-      // Notifications are blocked
-      toast.error('Notification permission denied.');
     }
   } catch (error) {
     console.error('Error getting permission or token: ', error);
-    toast.error('Error getting permission or token.');
   }
 };
 

--- a/src/pages/Trainee/Dashboard.tsx
+++ b/src/pages/Trainee/Dashboard.tsx
@@ -22,7 +22,7 @@ import InbodyModal from '@components/Trainee/InbodyModal';
 import Calendar from '@components/Trainee/Calendar';
 import { hexToRgba } from 'src/utils/hexToRgba';
 import useModals from 'src/hooks/useModals';
-import { user } from 'src/stores/userStore';
+import useUserStore from 'src/stores/userStore';
 
 Chart.register(
   CategoryScale,
@@ -212,6 +212,7 @@ export interface InfoData {
 }
 
 const Dashboard: React.FC = () => {
+  const user = useUserStore(state => state.user);
   const [editInfo, setEditInfo] = useState(true);
   const { openModal, closeModal, isOpen } = useModals();
   const [selectedDate, setSelectedDate] = useState<Date | null>(new Date());

--- a/src/pages/Trainee/Session.tsx
+++ b/src/pages/Trainee/Session.tsx
@@ -9,7 +9,7 @@ import { AddButton } from '@components/Common/AddButton';
 import AddSessionModal, {
   SessionDataType,
 } from '@components/Trainee/AddSessionModal';
-import { user } from 'src/stores/userStore';
+import useUserStore from 'src/stores/userStore';
 import useModals from 'src/hooks/useModals';
 
 const Wrapper = styled.div`
@@ -93,6 +93,7 @@ const sessions: Session[] = [
 ];
 
 const Session: React.FC = () => {
+  const user = useUserStore(state => state.user);
   const [images, setImages] = useState<string[]>([]);
   const observerRef = useRef<HTMLDivElement | null>(null);
   const imageContainerRef = useRef<HTMLDivElement>(null);

--- a/src/routes/HomeRedirect.tsx
+++ b/src/routes/HomeRedirect.tsx
@@ -1,8 +1,11 @@
 import React from 'react';
 import { Navigate } from 'react-router-dom';
-import { user } from 'src/stores/userStore';
+
+import useUserStore from 'src/stores/userStore';
 
 const HomeRedirect: React.FC = () => {
+  const user = useUserStore(state => state.user);
+
   if (!user) {
     return <Navigate to="/login" />;
   }

--- a/src/routes/ProtectedRoute.tsx
+++ b/src/routes/ProtectedRoute.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
 import { Navigate, Outlet, useLocation } from 'react-router-dom';
 
-import { user } from 'src/stores/userStore';
+import useUserStore from 'src/stores/userStore';
 
 const ProtectedRoute: React.FC = () => {
   const location = useLocation();
+  const user = useUserStore(state => state.user);
 
   if (!user) {
     return <Navigate to="/login" state={{ from: location }} />;

--- a/src/routes/PublicRoute.tsx
+++ b/src/routes/PublicRoute.tsx
@@ -1,9 +1,11 @@
 import React from 'react';
 import { Navigate, Outlet } from 'react-router-dom';
 
-import { user } from 'src/stores/userStore';
+import useUserStore from 'src/stores/userStore';
 
 const PublicRoute: React.FC = () => {
+  const user = useUserStore(state => state.user);
+
   if (user) {
     return <Navigate to="/" />;
   }

--- a/src/routes/RoleProtectedRoute.tsx
+++ b/src/routes/RoleProtectedRoute.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
 import { Navigate, Outlet, useLocation } from 'react-router-dom';
 
-import { user } from 'src/stores/userStore';
+import useUserStore from 'src/stores/userStore';
 
 const RoleProtectedRoute: React.FC = () => {
   const location = useLocation();
+  const user = useUserStore(state => state.user);
 
   if (user?.role !== 'TRAINER') {
     return <Navigate to="/not-found" state={{ from: location }} replace />;

--- a/src/stores/userStore.ts
+++ b/src/stores/userStore.ts
@@ -1,21 +1,19 @@
-// api 연동 후 zustand 이용해 수정
+import { create } from 'zustand';
 
-interface User {
+export interface User {
   id: string;
-  role: string;
+  role: 'TRAINEE' | 'TRAINER';
+  unreadNotification: boolean;
 }
 
-// 로그인 하지 않은 유저 상태 테스트하려면 주석해제
-// export const user: User | null = null;
+interface UserState {
+  user: User | null;
+  setUser: (user: any) => void;
+}
 
-// 트레이너 유저 테스트하려면 주석해제
-export const user: User | null = {
-  id: '1',
-  role: 'TRAINER',
-};
+const useUserStore = create<UserState>(set => ({
+  user: null,
+  setUser: user => set({ user }),
+}));
 
-// 트레이니 유저 테스트하려면 주석해제
-// export const user: User | null = {
-//   id: '1',
-//   role: 'TRAINEE',
-// };
+export default useUserStore;


### PR DESCRIPTION
### 📝 관련 이슈
closed #55 

### ✨ 반영 브랜치
- FROM: `55-feat/api-setting`
- TO: `master`

### ✅ PR 내용
- [x] 유저 정보 전역 관리 (`zustand`)
> - AS-IS: `userStore` 파일에 임의의 유저 객체를 만들어서 로그인/비로그인 상태 흉내내어 개발
> - TO-BE: `zustand` 도입하여 유저 정보 조회 시 `userStore`의 `user` 상태 업데이트
> - Description: `setUser` 메소드를 사용하는 경우는 페이지 이동 할때마다 유저 정보 조회와 동시에 유저 정보 업데이트하는 경우밖에 없습니다. 그 외에는 유저 정보 필요한 곳에서 코드 추가`(const user = useUserStore(state => state.user))`하여 사용하면 됩니다. 기존에 유저 정보로 role 구분하는 컴포넌트들(`Header`, `Session`, `Dashboard` 및 각종 `routes`)에서는 미리 수정해두었습니다!
```
// src/stores/userStore.ts

import { create } from 'zustand';

export interface User {
  id: string;
  role: 'TRAINEE' | 'TRAINER';
  unreadNotification: boolean;
}

interface UserState {
  user: User | null;
  setUser: (user: any) => void;
}

const useUserStore = create<UserState>(set => ({
  user: null,
  setUser: user => set({ user }),
}));

export default useUserStore;

```

- [x] axios instance 작업
> - `api` 폴더를 만들어 `axios instance` 파일과 기능별로 폴더링한 `api`들을 모아둡니다.
> - `axiosInstance`에서 서버 url을 `base url`로 설정하고, `http cookie` 사용을 위해 `withCredentials: true` 옵션을 추가합니다.
> - 현재 `request`에 대한 인터셉터는 없고, `response`에 대한 인터셉터를 추가해서 `401`에러(토큰없는 경우)를 받으면 로그인페이지로 이동시키고, `404`에러(요청 리소스 없는 경우)를 받으면 404페이지로 이동시킵니다.
```
// src/api/axiosInstance.ts

import axios, { AxiosError, AxiosResponse } from 'axios';
import { NavigateFunction } from 'react-router-dom';

import useUserStore from 'src/stores/userStore';

const axiosInstance = axios.create({
  baseURL: 'https://api.training-diary.co.kr/api',
  withCredentials: true,
});

const createInterceptor = (navigate: NavigateFunction): void => {
  axiosInstance.interceptors.response.use(
    (response: AxiosResponse) => response,
    (error: AxiosError) => {
      if (error.response?.status === 401) {
        const setUser = useUserStore.getState().setUser;
        setUser(null);

        navigate('/login');
      } else if (error.response?.status === 404) {
        navigate('/not-found');
      }
      return Promise.reject(error);
    }
  );
};

export { axiosInstance, createInterceptor };

```

- [x] MSW와 Firebase Cloud Messaging 서비스워커 충돌 문제 해결
> - AS-IS: 새로고침할 때마다 서비스워커 충돌하여 흰 화면 렌더링. 개발자도구에서 clear Data를 해야 화면이 보였음.
> - TO-BE: FCM 서비스워커 등록시점과 MSW 등록시점을 분리. FCM 전체로직 내에서도 2가지 단계로 분리(서비스워커는 main.tsx에서 서비스 진입시점에 등록하고, 알림 권한을 허용받거나 토큰을 생성하는 로직은 로그인 API 요청 이후 시점으로 분리)

### 🌐 테스트 배포
- [x] 테스트 배포하여 잘 동작하는 지 확인했나요?
> - 테스트 배포 주소: https://sumin-test-training-diary.netlify.app/trainee/1/diet/1
> - 테스트 환경 (Desktop): MacOS (Chrome / Safari / Firefox / Edge)
> - 테스트 환경 (Mobile): Android (Chrome / 삼성인터넷)

### 📌 ETC
- react-query 설치 및 적용은 accessToken이 담긴 cookie 문제가 해결이 되어야 로컬에서 작업이 가능합니다. 해당 문제 서버와 해결 후 다음 작업 때 반영해서 올리겠습니다! 일단은 GET 요청을 제외한 나머지 API 연동부터 시작해주세요 🧚
- 페이지 컴포넌트의 시작지점에서 `useFetchUser` 훅 사용해주세요! 알림 정보 업데이트를 위해서 주기적인 유저 상태 업데이트가 필요합니다.