### PR TITLE
[FEAT] 트레이너 홈 > 운동 종류 관리 탭 API 연동 #66

### DIFF
--- a/src/api/trainer.ts
+++ b/src/api/trainer.ts
@@ -1,6 +1,7 @@
 import { NavigateFunction } from 'react-router-dom';
 
 import { axiosInstance, createInterceptor } from './axiosInstance';
+import { WorkoutDataType } from '@pages/Trainer/WorkOutManagement';
 
 let isInterceptorCreated = false;
 
@@ -25,6 +26,23 @@ const CreateTrainerApi = (navigate: NavigateFunction) => {
 
     deleteTrainee: (ptContractId: number) =>
       axiosInstance.post('/pt-contracts/terminate', { ptContractId }),
+
+    getWorkouts: (page: number, size: number) =>
+      axiosInstance.get('/workout-types', {
+        params: {
+          page,
+          size,
+        },
+      }),
+
+    addWorkouts: (workoutData: WorkoutDataType) =>
+      axiosInstance.post('/workout-types', workoutData),
+
+    editWorkouts: (workoutData: WorkoutDataType) =>
+      axiosInstance.put('/workout-types', workoutData),
+
+    deleteWorkouts: (id: number) =>
+      axiosInstance.delete(`/workout-types/${id}`),
   };
 };
 

--- a/src/api/trainer.ts
+++ b/src/api/trainer.ts
@@ -1,7 +1,10 @@
 import { NavigateFunction } from 'react-router-dom';
 
 import { axiosInstance, createInterceptor } from './axiosInstance';
-import { WorkoutDataType } from '@pages/Trainer/WorkOutManagement';
+import {
+  AddWorkoutDataType,
+  EditWorkoutDataType,
+} from '@pages/Trainer/WorkOutManagement';
 
 let isInterceptorCreated = false;
 
@@ -35,10 +38,10 @@ const CreateTrainerApi = (navigate: NavigateFunction) => {
         },
       }),
 
-    addWorkouts: (workoutData: WorkoutDataType) =>
+    addWorkouts: (workoutData: AddWorkoutDataType) =>
       axiosInstance.post('/workout-types', workoutData),
 
-    editWorkouts: (workoutData: WorkoutDataType) =>
+    editWorkouts: (workoutData: EditWorkoutDataType) =>
       axiosInstance.put('/workout-types', workoutData),
 
     deleteWorkouts: (id: number) =>

--- a/src/components/Trainer/AddWorkOutModal.tsx
+++ b/src/components/Trainer/AddWorkOutModal.tsx
@@ -128,11 +128,6 @@ const AddWorkOutModal: React.FC<AddWorkOutModalProps> = ({
       setErrorAlert('주의사항을 입력해주세요.');
       return;
     } else if (
-      'weightInputRequired' in formState &&
-      'setInputRequired' in formState &&
-      'repInputRequired' in formState &&
-      'timeInputRequired' in formState &&
-      'speedInputRequired' in formState &&
       !formState.weightInputRequired &&
       !formState.setInputRequired &&
       !formState.repInputRequired &&

--- a/src/components/Trainer/AddWorkOutModal.tsx
+++ b/src/components/Trainer/AddWorkOutModal.tsx
@@ -1,6 +1,8 @@
-import React from 'react';
+import React, { useState } from 'react';
 import styled from 'styled-components';
+
 import Modal from '@components/Common/Modal/Modal';
+import Alert from '@components/Common/Alert/Alert';
 import { WorkoutDataType } from '@pages/Trainer/WorkOutManagement';
 
 // 스타일 정의
@@ -90,7 +92,9 @@ const AddWorkOutModal: React.FC<AddWorkOutModalProps> = ({
   formState,
   setFormState,
 }) => {
-  const handleInputChange = (field: string, value: string) => {
+  const [errorAlert, setErrorAlert] = useState<string>('');
+
+  const handleInputChange = (field: keyof WorkoutDataType, value: string) => {
     setFormState(prev => ({
       ...prev,
       [field]: value,
@@ -100,11 +104,16 @@ const AddWorkOutModal: React.FC<AddWorkOutModalProps> = ({
   const handleAttributeChange = (attr: keyof WorkoutDataType) => {
     setFormState(prev => ({
       ...prev,
-      [attr]: !prev[attr],
+      [attr]: !prev[attr] as boolean,
     }));
   };
 
   const handleSave = () => {
+    if (!formState.name || !formState.targetMuscle || !formState.remarks) {
+      setErrorAlert('내용을 입력해주세요.');
+      return;
+    }
+
     const newWorkout: WorkoutDataType = {
       ...formState,
       id: formState.id || Date.now(), // 새로 추가하는 경우에만 임시 ID 할당
@@ -117,6 +126,8 @@ const AddWorkOutModal: React.FC<AddWorkOutModalProps> = ({
     }
     onClose();
   };
+
+  const onCloseErrorAlert = () => setErrorAlert('');
 
   return (
     <Modal
@@ -150,38 +161,44 @@ const AddWorkOutModal: React.FC<AddWorkOutModalProps> = ({
           onChange={e => handleInputChange('remarks', e.target.value)}
         ></TextArea>
       </FormGroup>
-      <FormGroup>
-        <Label>속성 값:</Label>
-        <CheckboxGroup>
-          {[
-            'weightInputRequired',
-            'setInputRequired',
-            'repInputRequired',
-            'timeInputRequired',
-            'speedInputRequired',
-          ].map(attr => (
-            <CheckboxLabel
-              key={attr}
-              className={
-                formState[attr as keyof WorkoutDataType] ? 'selected' : ''
-              }
-            >
-              <input
-                type="checkbox"
-                checked={formState[attr as keyof WorkoutDataType]}
-                onChange={() =>
-                  handleAttributeChange(attr as keyof WorkoutDataType)
+      {formState.id ? null : (
+        <FormGroup>
+          <Label>속성 값:</Label>
+          <CheckboxGroup>
+            {[
+              'weightInputRequired',
+              'setInputRequired',
+              'repInputRequired',
+              'timeInputRequired',
+              'speedInputRequired',
+            ].map(attr => (
+              <CheckboxLabel
+                key={attr}
+                className={
+                  formState[attr as keyof WorkoutDataType] ? 'selected' : ''
                 }
-              />
-              {attr === 'weightInputRequired' && '무게'}
-              {attr === 'setInputRequired' && '세트'}
-              {attr === 'repInputRequired' && '횟수'}
-              {attr === 'timeInputRequired' && '시간'}
-              {attr === 'speedInputRequired' && '속도'}
-            </CheckboxLabel>
-          ))}
-        </CheckboxGroup>
-      </FormGroup>
+              >
+                <input
+                  type="checkbox"
+                  checked={formState[attr as keyof WorkoutDataType] as boolean}
+                  onChange={() =>
+                    handleAttributeChange(attr as keyof WorkoutDataType)
+                  }
+                  disabled={formState.id ? true : false}
+                />
+                {attr === 'weightInputRequired' && '무게'}
+                {attr === 'setInputRequired' && '세트'}
+                {attr === 'repInputRequired' && '횟수'}
+                {attr === 'timeInputRequired' && '시간'}
+                {attr === 'speedInputRequired' && '속도'}
+              </CheckboxLabel>
+            ))}
+          </CheckboxGroup>
+        </FormGroup>
+      )}
+      {errorAlert && (
+        <Alert $type="error" text={errorAlert} onClose={onCloseErrorAlert} />
+      )}
     </Modal>
   );
 };

--- a/src/components/Trainer/AddWorkOutModal.tsx
+++ b/src/components/Trainer/AddWorkOutModal.tsx
@@ -109,8 +109,23 @@ const AddWorkOutModal: React.FC<AddWorkOutModalProps> = ({
   };
 
   const handleSave = () => {
-    if (!formState.name || !formState.targetMuscle || !formState.remarks) {
-      setErrorAlert('내용을 입력해주세요.');
+    if (!formState.name) {
+      setErrorAlert('운동명을 입력해주세요.');
+      return;
+    } else if (!formState.targetMuscle) {
+      setErrorAlert('자극 부위를 입력해주세요.');
+      return;
+    } else if (!formState.remarks) {
+      setErrorAlert('주의사항을 입력해주세요.');
+      return;
+    } else if (
+      !formState.weightInputRequired &&
+      !formState.setInputRequired &&
+      !formState.repInputRequired &&
+      !formState.timeInputRequired &&
+      !formState.speedInputRequired
+    ) {
+      setErrorAlert('속성을 입력해주세요.');
       return;
     }
 

--- a/src/components/Trainer/AddWorkOutModal.tsx
+++ b/src/components/Trainer/AddWorkOutModal.tsx
@@ -1,6 +1,6 @@
+// AddWorkOutModal.tsx
 import React from 'react';
 import styled from 'styled-components';
-
 import Modal from '@components/Common/Modal/Modal';
 import { WorkoutDataType } from '@pages/Trainer/WorkOutManagement';
 
@@ -78,32 +78,9 @@ interface AddWorkOutModalProps {
   isOpen: boolean;
   onClose: () => void;
   onSave: (workout: WorkoutDataType) => void;
-  formState: {
-    name: string;
-    targetMuscle: string;
-    remark: string;
-    attributes: {
-      weight: boolean;
-      set: boolean;
-      rep: boolean;
-      time: boolean;
-      speed: boolean;
-    };
-  };
-  setFormState: React.Dispatch<
-    React.SetStateAction<{
-      name: string;
-      targetMuscle: string;
-      remark: string;
-      attributes: {
-        weight: boolean;
-        set: boolean;
-        rep: boolean;
-        time: boolean;
-        speed: boolean;
-      };
-    }>
-  >;
+  onEdit: (workout: WorkoutDataType) => void;
+  formState: WorkoutDataType;
+  setFormState: React.Dispatch<React.SetStateAction<WorkoutDataType>>;
 }
 
 const AddWorkOutModal: React.FC<AddWorkOutModalProps> = ({
@@ -120,27 +97,17 @@ const AddWorkOutModal: React.FC<AddWorkOutModalProps> = ({
     }));
   };
 
-  const handleAttributeChange = (attr: keyof typeof formState.attributes) => {
+  const handleAttributeChange = (attr: keyof WorkoutDataType) => {
     setFormState(prev => ({
       ...prev,
-      attributes: {
-        ...prev.attributes,
-        [attr]: !prev.attributes[attr],
-      },
+      [attr]: !prev[attr],
     }));
   };
 
   const handleSave = () => {
     const newWorkout: WorkoutDataType = {
-      id: Date.now(), // 임시 ID 할당
-      name: formState.name,
-      targetMuscle: formState.targetMuscle,
-      remark: formState.remark,
-      weightInputRequired: formState.attributes.weight,
-      setInputRequired: formState.attributes.set,
-      repInputRequired: formState.attributes.rep,
-      timeInputRequired: formState.attributes.time,
-      speedInputRequired: formState.attributes.speed,
+      ...formState,
+      id: formState.id || Date.now(), // 새로 추가하는 경우에만 임시 ID 할당
     };
     onSave(newWorkout);
     onClose();
@@ -148,12 +115,12 @@ const AddWorkOutModal: React.FC<AddWorkOutModalProps> = ({
 
   return (
     <Modal
-      title={formState.name ? '운동 종류 수정' : '운동 종류 추가'}
+      title={formState.id ? '운동 종류 수정' : '운동 종류 추가'}
       type="custom"
       isOpen={isOpen}
       onClose={onClose}
       onSave={handleSave}
-      btnConfirm={formState.name ? '수정' : '추가'}
+      btnConfirm={formState.id ? '수정' : '추가'}
     >
       <FormGroup>
         <Label>운동명:</Label>
@@ -174,40 +141,38 @@ const AddWorkOutModal: React.FC<AddWorkOutModalProps> = ({
       <FormGroup>
         <Label>주의사항 노트:</Label>
         <TextArea
-          value={formState.remark}
-          onChange={e => handleInputChange('remark', e.target.value)}
+          value={formState.remarks}
+          onChange={e => handleInputChange('remarks', e.target.value)}
         ></TextArea>
       </FormGroup>
       <FormGroup>
         <Label>속성 값:</Label>
         <CheckboxGroup>
-          {Object.keys(formState.attributes).map(attr => (
+          {[
+            'weightInputRequired',
+            'setInputRequired',
+            'repInputRequired',
+            'timeInputRequired',
+            'speedInputRequired',
+          ].map(attr => (
             <CheckboxLabel
               key={attr}
               className={
-                formState.attributes[attr as keyof typeof formState.attributes]
-                  ? 'selected'
-                  : ''
+                formState[attr as keyof WorkoutDataType] ? 'selected' : ''
               }
             >
               <input
                 type="checkbox"
-                checked={
-                  formState.attributes[
-                    attr as keyof typeof formState.attributes
-                  ]
-                }
+                checked={formState[attr as keyof WorkoutDataType]}
                 onChange={() =>
-                  handleAttributeChange(
-                    attr as keyof typeof formState.attributes
-                  )
+                  handleAttributeChange(attr as keyof WorkoutDataType)
                 }
               />
-              {attr === 'weight' && '무게'}
-              {attr === 'set' && '세트'}
-              {attr === 'rep' && '횟수'}
-              {attr === 'time' && '시간'}
-              {attr === 'speed' && '속도'}
+              {attr === 'weightInputRequired' && '무게'}
+              {attr === 'setInputRequired' && '세트'}
+              {attr === 'repInputRequired' && '횟수'}
+              {attr === 'timeInputRequired' && '시간'}
+              {attr === 'speedInputRequired' && '속도'}
             </CheckboxLabel>
           ))}
         </CheckboxGroup>

--- a/src/components/Trainer/AddWorkOutModal.tsx
+++ b/src/components/Trainer/AddWorkOutModal.tsx
@@ -1,4 +1,3 @@
-// AddWorkOutModal.tsx
 import React from 'react';
 import styled from 'styled-components';
 import Modal from '@components/Common/Modal/Modal';
@@ -87,6 +86,7 @@ const AddWorkOutModal: React.FC<AddWorkOutModalProps> = ({
   isOpen,
   onClose,
   onSave,
+  onEdit,
   formState,
   setFormState,
 }) => {
@@ -109,7 +109,12 @@ const AddWorkOutModal: React.FC<AddWorkOutModalProps> = ({
       ...formState,
       id: formState.id || Date.now(), // 새로 추가하는 경우에만 임시 ID 할당
     };
-    onSave(newWorkout);
+
+    if (formState.id) {
+      onEdit(newWorkout);
+    } else {
+      onSave(newWorkout);
+    }
     onClose();
   };
 

--- a/src/components/Trainer/AddWorkOutModal.tsx
+++ b/src/components/Trainer/AddWorkOutModal.tsx
@@ -3,7 +3,11 @@ import styled from 'styled-components';
 
 import Modal from '@components/Common/Modal/Modal';
 import Alert from '@components/Common/Alert/Alert';
-import { WorkoutDataType } from '@pages/Trainer/WorkOutManagement';
+import {
+  AddWorkoutDataType,
+  EditWorkoutDataType,
+  WorkoutDataType,
+} from '@pages/Trainer/WorkOutManagement';
 
 // 스타일 정의
 const FormGroup = styled.div`
@@ -78,10 +82,12 @@ const CheckboxLabel = styled.label`
 interface AddWorkOutModalProps {
   isOpen: boolean;
   onClose: () => void;
-  onSave: (workout: WorkoutDataType) => void;
-  onEdit: (workout: WorkoutDataType) => void;
-  formState: WorkoutDataType;
-  setFormState: React.Dispatch<React.SetStateAction<WorkoutDataType>>;
+  onSave: (workout: AddWorkoutDataType) => void;
+  onEdit: (workout: EditWorkoutDataType) => void;
+  formState: AddWorkoutDataType | WorkoutDataType;
+  setFormState: React.Dispatch<
+    React.SetStateAction<WorkoutDataType | AddWorkoutDataType>
+  >;
 }
 
 const AddWorkOutModal: React.FC<AddWorkOutModalProps> = ({
@@ -94,14 +100,17 @@ const AddWorkOutModal: React.FC<AddWorkOutModalProps> = ({
 }) => {
   const [errorAlert, setErrorAlert] = useState<string>('');
 
-  const handleInputChange = (field: keyof WorkoutDataType, value: string) => {
+  const handleInputChange = (
+    field: keyof AddWorkoutDataType,
+    value: string
+  ) => {
     setFormState(prev => ({
       ...prev,
       [field]: value,
     }));
   };
 
-  const handleAttributeChange = (attr: keyof WorkoutDataType) => {
+  const handleAttributeChange = (attr: keyof AddWorkoutDataType) => {
     setFormState(prev => ({
       ...prev,
       [attr]: !prev[attr] as boolean,
@@ -119,6 +128,11 @@ const AddWorkOutModal: React.FC<AddWorkOutModalProps> = ({
       setErrorAlert('주의사항을 입력해주세요.');
       return;
     } else if (
+      'weightInputRequired' in formState &&
+      'setInputRequired' in formState &&
+      'repInputRequired' in formState &&
+      'timeInputRequired' in formState &&
+      'speedInputRequired' in formState &&
       !formState.weightInputRequired &&
       !formState.setInputRequired &&
       !formState.repInputRequired &&
@@ -129,15 +143,15 @@ const AddWorkOutModal: React.FC<AddWorkOutModalProps> = ({
       return;
     }
 
-    const newWorkout: WorkoutDataType = {
-      ...formState,
-      id: formState.id || Date.now(), // 새로 추가하는 경우에만 임시 ID 할당
-    };
-
-    if (formState.id) {
-      onEdit(newWorkout);
+    if ('id' in formState) {
+      onEdit({
+        workoutTypeId: formState.id,
+        name: formState.name,
+        targetMuscle: formState.targetMuscle,
+        remarks: formState.remarks,
+      });
     } else {
-      onSave(newWorkout);
+      onSave(formState as AddWorkoutDataType);
     }
     onClose();
   };
@@ -146,12 +160,12 @@ const AddWorkOutModal: React.FC<AddWorkOutModalProps> = ({
 
   return (
     <Modal
-      title={formState.id ? '운동 종류 수정' : '운동 종류 추가'}
+      title={'id' in formState ? '운동 종류 수정' : '운동 종류 추가'}
       type="custom"
       isOpen={isOpen}
       onClose={onClose}
       onSave={handleSave}
-      btnConfirm={formState.id ? '수정' : '추가'}
+      btnConfirm={'id' in formState ? '수정' : '추가'}
     >
       <FormGroup>
         <Label>운동명:</Label>
@@ -176,7 +190,7 @@ const AddWorkOutModal: React.FC<AddWorkOutModalProps> = ({
           onChange={e => handleInputChange('remarks', e.target.value)}
         ></TextArea>
       </FormGroup>
-      {formState.id ? null : (
+      {'id' in formState ? null : (
         <FormGroup>
           <Label>속성 값:</Label>
           <CheckboxGroup>
@@ -190,16 +204,18 @@ const AddWorkOutModal: React.FC<AddWorkOutModalProps> = ({
               <CheckboxLabel
                 key={attr}
                 className={
-                  formState[attr as keyof WorkoutDataType] ? 'selected' : ''
+                  formState[attr as keyof AddWorkoutDataType] ? 'selected' : ''
                 }
               >
                 <input
                   type="checkbox"
-                  checked={formState[attr as keyof WorkoutDataType] as boolean}
-                  onChange={() =>
-                    handleAttributeChange(attr as keyof WorkoutDataType)
+                  checked={
+                    formState[attr as keyof AddWorkoutDataType] as boolean
                   }
-                  disabled={formState.id ? true : false}
+                  onChange={() =>
+                    handleAttributeChange(attr as keyof AddWorkoutDataType)
+                  }
+                  disabled={'id' in formState ? true : false}
                 />
                 {attr === 'weightInputRequired' && '무게'}
                 {attr === 'setInputRequired' && '세트'}

--- a/src/components/Trainer/Card.tsx
+++ b/src/components/Trainer/Card.tsx
@@ -26,7 +26,6 @@ const CardHeader = styled.div`
 const TitleGroup = styled.div`
   width: 100%;
   display: flex;
-  flex-grow: 1;
   align-items: center;
   gap: 4px;
   color: ${({ theme }) => theme.colors.gray900};
@@ -48,11 +47,13 @@ const ButtonGroup = styled.div`
   justify-content: flex-end;
   gap: 10px;
   width: 100%;
+  flex: 1;
 
   & > button {
     line-height: 1;
     font-size: 1.2rem;
     max-width: 60px;
+    padding: 8px 20px;
   }
 `;
 

--- a/src/components/Trainer/Card.tsx
+++ b/src/components/Trainer/Card.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import styled from 'styled-components';
 
 import Button from '@components/Common/Button/Button';
+import { WorkoutDataType } from '@pages/Trainer/WorkOutManagement';
 import { hexToRgba } from 'src/utils/hexToRgba';
 
 const CardWrapper = styled.div`
@@ -86,17 +87,7 @@ const Tag = styled.span`
 `;
 
 interface CardProps {
-  workout: {
-    id: number;
-    name: string;
-    targetMuscle: string;
-    remarks: string;
-    weightInputRequired: boolean;
-    setInputRequired: boolean;
-    repInputRequired: boolean;
-    timeInputRequired: boolean;
-    speedInputRequired: boolean;
-  };
+  workout: WorkoutDataType;
   onDelete: (id: number) => void;
   onEdit: (id: number) => void;
 }

--- a/src/components/Trainer/Card.tsx
+++ b/src/components/Trainer/Card.tsx
@@ -90,7 +90,7 @@ interface CardProps {
     id: number;
     name: string;
     targetMuscle: string;
-    remark: string;
+    remarks: string;
     weightInputRequired: boolean;
     setInputRequired: boolean;
     repInputRequired: boolean;
@@ -119,7 +119,7 @@ const Card: React.FC<CardProps> = ({ workout, onDelete, onEdit }) => {
         </ButtonGroup>
       </CardHeader>
       <Divider />
-      <CardBody>{workout.remark}</CardBody>
+      <CardBody>{workout.remarks}</CardBody>
       <Tags>
         {workout.weightInputRequired && <Tag>#무게</Tag>}
         {workout.setInputRequired && <Tag>#세트횟수</Tag>}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -20,12 +20,12 @@ async function enableMocking() {
 }
 
 registerServiceWorker();
-enableMocking().then(() => {
-  ReactDOM.createRoot(document.getElementById('root')!).render(
-    <React.StrictMode>
-      <QueryClientProvider client={queryClient}>
-        <App />
-      </QueryClientProvider>
-    </React.StrictMode>
-  );
-});
+// enableMocking().then(() => {
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <QueryClientProvider client={queryClient}>
+      <App />
+    </QueryClientProvider>
+  </React.StrictMode>
+);
+// });

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -20,12 +20,12 @@ async function enableMocking() {
 }
 
 registerServiceWorker();
-// enableMocking().then(() => {
-ReactDOM.createRoot(document.getElementById('root')!).render(
-  <React.StrictMode>
-    <QueryClientProvider client={queryClient}>
-      <App />
-    </QueryClientProvider>
-  </React.StrictMode>
-);
-// });
+enableMocking().then(() => {
+  ReactDOM.createRoot(document.getElementById('root')!).render(
+    <React.StrictMode>
+      <QueryClientProvider client={queryClient}>
+        <App />
+      </QueryClientProvider>
+    </React.StrictMode>
+  );
+});

--- a/src/pages/Trainer/TraineeManagement.tsx
+++ b/src/pages/Trainer/TraineeManagement.tsx
@@ -266,8 +266,16 @@ const TraineeManagement: React.FC = () => {
                   </TraineeItem>
                 ))
               ) : (
-                <li style={{ fontSize: '1.4rem' }}>
-                  등록된 트레이니가 없습니다.
+                <li
+                  style={{
+                    fontSize: '1.4rem',
+                    display: 'flex',
+                    justifyContent: 'center',
+                    height: '50vh',
+                    alignItems: 'center',
+                  }}
+                >
+                  트레이너를 등록해주세요.
                 </li>
               )}
             </TraineeList>

--- a/src/pages/Trainer/TraineeManagement.tsx
+++ b/src/pages/Trainer/TraineeManagement.tsx
@@ -152,7 +152,7 @@ const TraineeManagement: React.FC = () => {
         setTraineeData(res.data.content);
       }
     } catch (error) {
-      console.error('Failed to fetch trainee data', error);
+      console.error('트레이니 조회 에러: ', error);
     } finally {
       setLoading(false);
     }

--- a/src/pages/Trainer/WorkOutManagement.tsx
+++ b/src/pages/Trainer/WorkOutManagement.tsx
@@ -135,12 +135,12 @@ const WorkOutManagement: React.FC = () => {
         name: workout.name,
         targetMuscle: workout.targetMuscle,
         remarks: workout.remarks,
-        id: 0,
-        weightInputRequired: false,
-        setInputRequired: false,
-        repInputRequired: false,
-        timeInputRequired: false,
-        speedInputRequired: false,
+        weightInputRequired: workout.weightInputRequired,
+        setInputRequired: workout.setInputRequired,
+        repInputRequired: workout.repInputRequired,
+        timeInputRequired: workout.timeInputRequired,
+        speedInputRequired: workout.speedInputRequired,
+        id: workout.id,
       });
       refetch();
       closeModal('addModal');

--- a/src/pages/Trainer/WorkOutManagement.tsx
+++ b/src/pages/Trainer/WorkOutManagement.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { useQuery } from 'react-query';
+import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 
 import addBtn from '@icons/home/addbtn.svg';
@@ -10,7 +11,6 @@ import Alert from '@components/Common/Alert/Alert';
 import Card from '@components/Trainer/Card';
 import AddWorkOutModal from '@components/Trainer/AddWorkOutModal';
 import CreateTrainerApi from 'src/api/trainer';
-import { useNavigate } from 'react-router-dom';
 import useModals from 'src/hooks/useModals';
 import useFetchUser from 'src/hooks/useFetchUser';
 
@@ -24,7 +24,6 @@ const Wrapper = styled.div`
 
 // data type 정의
 export interface WorkoutDataType {
-  workoutTypeId?: number;
   id: number;
   name: string;
   targetMuscle: string;
@@ -34,6 +33,24 @@ export interface WorkoutDataType {
   repInputRequired: boolean;
   timeInputRequired: boolean;
   speedInputRequired: boolean;
+}
+
+export interface AddWorkoutDataType {
+  name: string;
+  targetMuscle: string;
+  remarks: string;
+  weightInputRequired: boolean;
+  setInputRequired: boolean;
+  repInputRequired: boolean;
+  timeInputRequired: boolean;
+  speedInputRequired: boolean;
+}
+
+export interface EditWorkoutDataType {
+  workoutTypeId: number;
+  name: string;
+  targetMuscle: string;
+  remarks: string;
 }
 
 const WorkOutManagement: React.FC = () => {
@@ -47,7 +64,9 @@ const WorkOutManagement: React.FC = () => {
   );
   const [page] = useState(0);
   const [size] = useState(20);
-  const [formState, setFormState] = useState<WorkoutDataType>({
+  const [formState, setFormState] = useState<
+    WorkoutDataType | AddWorkoutDataType
+  >({
     id: 0,
     name: '',
     targetMuscle: '',
@@ -69,8 +88,7 @@ const WorkOutManagement: React.FC = () => {
 
   const workouts: WorkoutDataType[] = data?.data.content || [];
 
-  const initialFormState = {
-    id: 0,
+  const initialFormState: AddWorkoutDataType = {
     name: '',
     targetMuscle: '',
     remarks: '',
@@ -117,7 +135,7 @@ const WorkOutManagement: React.FC = () => {
   };
 
   // 운동 종류 추가
-  const handleSaveInput = async (workout: WorkoutDataType) => {
+  const handleSaveInput = async (workout: AddWorkoutDataType) => {
     try {
       await trainerApi.addWorkouts(workout);
       refetch();
@@ -128,20 +146,9 @@ const WorkOutManagement: React.FC = () => {
   };
 
   // 운동 종류 수정
-  const handleEditInput = async (workout: WorkoutDataType) => {
+  const handleEditInput = async (workout: EditWorkoutDataType) => {
     try {
-      await trainerApi.editWorkouts({
-        workoutTypeId: workout.id,
-        name: workout.name,
-        targetMuscle: workout.targetMuscle,
-        remarks: workout.remarks,
-        weightInputRequired: workout.weightInputRequired,
-        setInputRequired: workout.setInputRequired,
-        repInputRequired: workout.repInputRequired,
-        timeInputRequired: workout.timeInputRequired,
-        speedInputRequired: workout.speedInputRequired,
-        id: workout.id,
-      });
+      await trainerApi.editWorkouts(workout);
       refetch();
       closeModal('addModal');
     } catch (error) {
@@ -173,18 +180,33 @@ const WorkOutManagement: React.FC = () => {
   return (
     <SectionWrapper>
       <Wrapper>
-        {isLoading ? (
-          <div>운동 종류 목록 로딩중...</div>
+        {workouts.length > 0 ? (
+          isLoading ? (
+            <div>운동 종류 목록 로딩중...</div>
+          ) : (
+            workouts.map(workout => (
+              <Card
+                key={workout.id}
+                workout={workout}
+                onDelete={() => handleOpenDeleteModal(workout.id)}
+                onEdit={() => handleOpenEditModal(workout)}
+              />
+            ))
+          )
         ) : (
-          workouts.map(workout => (
-            <Card
-              key={workout.id}
-              workout={workout}
-              onDelete={() => handleOpenDeleteModal(workout.id)}
-              onEdit={() => handleOpenEditModal(workout)}
-            />
-          ))
+          <div
+            style={{
+              fontSize: '1.4rem',
+              display: 'flex',
+              justifyContent: 'center',
+              height: '50vh',
+              alignItems: 'center',
+            }}
+          >
+            운동 종류를 생성해주세요.
+          </div>
         )}
+
         {/* Add button 추가 */}
         <AddButton onClick={handleOpenAddModal}>
           <img src={addBtn} alt="add button" />

--- a/src/pages/Trainer/WorkOutManagement.tsx
+++ b/src/pages/Trainer/WorkOutManagement.tsx
@@ -45,8 +45,8 @@ const WorkOutManagement: React.FC = () => {
   const [selectedWorkoutId, setSelectedWorkoutId] = useState<number | null>(
     null
   );
-  const [page, setPage] = useState(0);
-  const [size, setSize] = useState(10);
+  const [page] = useState(0);
+  const [size] = useState(20);
   const [formState, setFormState] = useState<WorkoutDataType>({
     id: 0,
     name: '',


### PR DESCRIPTION
### 📝 관련 이슈
closed #66

### ✨ 반영 브랜치
<!-- 어떤 브랜치에서 어떤 브랜치로 merge하는지 적어주세요 -->
- FROM: `66-feat/trainer-workout-type-api`
- TO: `master`

### ✅ PR 내용
<!-- 기능마다 아래 템플릿으로 PR에 대한 설명을 적어주세요 (기능별 AS-IS, TO-BE, 변경이유 등) -->
- [x]  운동 종류 목록 조회 API 연동
> - 페이지와 사이즈를 파라미터로 전달하여 서버로부터 `운동 종류` 데이터를 받아옵니다. 현재 `useQuery`를 적용해서 사용해둔 상태인데, 올바르게 사용했는지 확인 부탁드립니다. 아직 무한 스크롤을 연동하기 전이라 정확한 적용이 어려웠습니다.
```typescript
getWorkouts: (page: number, size: number) =>
      axiosInstance.get('/workout-types', {
        params: {
          page,
          size,
        },
      })
```

- [x]  운동 종류 생성 API 연동
> - 사용자가 입력한 데이터를 서버로 전송하여 새로운 운동 종류를 생성하는 기능을 추가했습니다.
    추가 input 유효성 검사를 진행하여 모든 값을 필수로 받아오고 있습니다.
```typescript
addWorkouts: (workoutData: WorkoutDataType) =>
      axiosInstance.post('/workout-types', workoutData)
```

- [x]  운동 종류 수정 API 연동
> - 기존의 운동 종류를 `수정`하는 기능을 구현했습니다. 수정된 데이터를 서버로 `전송`하여 해당 운동 종류를 `업데이트`합니다.
    기획 의도대로 `속성 값`은 수정할 수 없도록 구현했습니다. input을 `비활성화` 하고, 추가적으로 수정 버튼을 클릭하면 속성이 보이지 않도록 구현했습니다.
```typescript
editWorkouts: (workoutData: WorkoutDataType) =>
      axiosInstance.put('/workout-types', workoutData)
```

- [x]  운동 종류 삭제 API 연동
> - 선택한 운동 종류를 `삭제`하는 기능을 추가했습니다. 서버에 `삭제 요청`을 보내고, 성공 시 클라이언트에서 해당 항목을 `제거`합니다.
```typescript
deleteWorkouts: (id: number) =>
      axiosInstance.delete(`/workout-types/${id}`)
```

### 🌐 테스트 배포
<!-- 모바일 기기에서 진행한 테스트에 대해 적어주세요 -->
- [x] 테스트 배포하여 잘 동작하는 지 확인했나요?
> - 테스트 배포 주소: https://jm.training-diary.co.kr/
> - 테스트 환경 (Desktop): Windows(Chrome / Firefox / Edge)
> - 테스트 환경 (Mobile): ios (Safari)

### 📌 ETC
<!-- 레퍼런스, 참고할 사항, 질문 사항이 있다면 적어주세요 (Optional) -->
useQuery를 사용해보려고 노력은 했는데, 기본 적인 내용을 이용하다 보니 아직 정확히 사용했는지, 효율적으로 사용을 한 것인지 의문이 조금 들었습니다.. 확인 부탁드립니다!
그리고 수정 부분에서 조금 시간이 들었습니다. 수정하는 부분에서는 workoutTypeId가 따로 필요해서 id값을 보내주는 곳에서 조금 어려움을 겪었습니다.😣