### PR TITLE
[FEAT] Appointment > 주별 시간표 탭 API 연동 #70

### DIFF
--- a/src/api/appointment.ts
+++ b/src/api/appointment.ts
@@ -31,6 +31,9 @@ const CreateAppointmentApi = (navigate: NavigateFunction) => {
         dateTimes,
       }),
 
+    closeSchedules: (scheduleIds: number[]) =>
+      axiosInstance.post('/schedules/trainers/close', { scheduleIds }),
+
     getSchedules: (startDate: string, endDate: string) => {
       if (user?.role === 'TRAINER') {
         return axiosInstance.get('/schedules/trainers', {

--- a/src/api/appointment.ts
+++ b/src/api/appointment.ts
@@ -45,6 +45,12 @@ const CreateAppointmentApi = (navigate: NavigateFunction) => {
       }
     },
 
+    acceptSchedule: (scheduleId: number) =>
+      axiosInstance.post('/schedules/trainers/accept', { scheduleId }),
+
+    rejectSchedule: (scheduleId: number) =>
+      axiosInstance.post('/schedules/trainers/reject', { scheduleId }),
+
     getSchedules: (startDate: string, endDate: string) => {
       if (user?.role === 'TRAINER') {
         return axiosInstance.get('/schedules/trainers', {

--- a/src/api/appointment.ts
+++ b/src/api/appointment.ts
@@ -34,6 +34,17 @@ const CreateAppointmentApi = (navigate: NavigateFunction) => {
     closeSchedules: (scheduleIds: number[]) =>
       axiosInstance.post('/schedules/trainers/close', { scheduleIds }),
 
+    applySchedule: (scheduleId: number) =>
+      axiosInstance.post('/schedules/trainees/apply', { scheduleId }),
+
+    cancelSchedule: (scheduleId: number) => {
+      if (user?.role === 'TRAINER') {
+        return axiosInstance.post('/schedules/trainers/cancel', { scheduleId });
+      } else if (user?.role === 'TRAINEE') {
+        return axiosInstance.post('/schedules/trainees/cancel', { scheduleId });
+      }
+    },
+
     getSchedules: (startDate: string, endDate: string) => {
       if (user?.role === 'TRAINER') {
         return axiosInstance.get('/schedules/trainers', {

--- a/src/components/Appointment/MonthlyCalendar.tsx
+++ b/src/components/Appointment/MonthlyCalendar.tsx
@@ -4,7 +4,13 @@ import FullCalendar from '@fullcalendar/react';
 import dayGridPlugin from '@fullcalendar/daygrid';
 import interactionPlugin from '@fullcalendar/interaction';
 import { DatesSetArg, DayHeaderContentArg } from '@fullcalendar/core';
-import { addMonths, format, isBefore, startOfMonth } from 'date-fns';
+import {
+  addMonths,
+  format,
+  isBefore,
+  startOfDay,
+  startOfMonth,
+} from 'date-fns';
 
 import { hexToRgba } from 'src/utils/hexToRgba';
 import useCalendarStore from 'src/stores/calendarStore';
@@ -148,8 +154,15 @@ const MonthlyCalendar: React.FC<MonthlyCalendarProps> = ({
     const formattedDate = format(info.date, 'yyyy-MM-dd');
 
     if (
-      selectedButton !== null &&
+      selectedButton === 'open' &&
       isBefore(new Date(formattedDate), new Date())
+    ) {
+      return;
+    }
+
+    if (
+      selectedButton === 'register' &&
+      isBefore(new Date(formattedDate), startOfDay(new Date()))
     ) {
       return;
     }
@@ -203,8 +216,15 @@ const MonthlyCalendar: React.FC<MonthlyCalendarProps> = ({
         }
 
         if (
-          selectedButton !== null &&
+          selectedButton === 'open' &&
           isBefore(new Date(formattedDate), new Date())
+        ) {
+          dayNumberElement.classList.add('fc-has-event-number');
+        }
+
+        if (
+          selectedButton === 'register' &&
+          isBefore(new Date(formattedDate), startOfDay(new Date()))
         ) {
           dayNumberElement.classList.add('fc-has-event-number');
         }

--- a/src/components/Appointment/MonthlyCalendar.tsx
+++ b/src/components/Appointment/MonthlyCalendar.tsx
@@ -8,6 +8,7 @@ import {
   addMonths,
   format,
   isBefore,
+  isSameDay,
   startOfDay,
   startOfMonth,
 } from 'date-fns';
@@ -109,6 +110,10 @@ const FullCalendarWrapper = styled.div`
     color: ${({ theme }) => theme.colors.white};
   }
 
+  .fc-daygrid-day-number.fc-today {
+    border: 1px solid ${({ theme }) => theme.colors.main800};
+  }
+
   .fc-scrollgrid,
   table,
   td,
@@ -205,10 +210,15 @@ const MonthlyCalendar: React.FC<MonthlyCalendarProps> = ({
           'active-enabled',
           'fc-reserved-number',
           'fc-has-event-number',
-          'fc-selected-number'
+          'fc-selected-number',
+          'fc-today'
         );
 
         if (selectedButton === null) {
+          if (isSameDay(new Date(date), startOfDay(new Date()))) {
+            dayNumberElement.classList.add('fc-today');
+          }
+
           dayNumberElement.classList.add('active-enabled');
           if (reservedDates.includes(formattedDate)) {
             dayNumberElement.classList.add('fc-reserved-number');

--- a/src/components/Appointment/ScheduleDetail.tsx
+++ b/src/components/Appointment/ScheduleDetail.tsx
@@ -8,6 +8,7 @@ import Modal from '@components/Common/Modal/Modal';
 import { generateTimes } from 'src/utils/generateTimes';
 import useModals from 'src/hooks/useModals';
 import CreateAppointmentApi from 'src/api/appointment';
+import useUserStore from 'src/stores/userStore';
 
 const Wrapper = styled.div`
   display: flex;
@@ -107,7 +108,7 @@ const ButtonBox = styled.div`
   }
 `;
 
-const StatusButton = styled.button<{ $status: ScheduleStatus }>`
+const StatusButton = styled.button<{ $status: ScheduleStatus; role?: string }>`
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -118,58 +119,111 @@ const StatusButton = styled.button<{ $status: ScheduleStatus }>`
   width: 100%;
   max-width: 80px;
   white-space: nowrap;
-  background-color: ${({ theme, $status }) => {
-    switch ($status) {
-      case 'PAST':
-        return;
-      case 'EMPTY':
-        return theme.colors.main500;
-      case 'OPEN':
-        return theme.colors.gray700;
-      case 'RESERVE_APPLIED':
-        return theme.colors.main500;
-      case 'RESERVED':
-        return theme.colors.gray100;
-    }
-  }};
-  color: ${({ theme, $status }) => {
-    switch ($status) {
-      case 'PAST':
-        return;
-      case 'EMPTY':
-      case 'OPEN':
-      case 'RESERVE_APPLIED':
-        return theme.colors.white;
-      case 'RESERVED':
-        return theme.colors.gray600;
-    }
-  }};
-  border: ${({ theme, $status }) => {
-    switch ($status) {
-      case 'PAST':
-        return;
-      case 'EMPTY':
-      case 'OPEN':
-      case 'RESERVE_APPLIED':
-        return 'none';
-      case 'RESERVED':
-        return `1px solid ${theme.colors.gray300}`;
-    }
-  }};
-
-  &:active {
-    background-color: ${({ theme, $status }) => {
+  background-color: ${({ theme, $status, role }) => {
+    if (role === 'TRAINER') {
       switch ($status) {
         case 'PAST':
           return;
         case 'EMPTY':
-          return theme.colors.main700;
+          return theme.colors.main500;
         case 'OPEN':
-          return theme.colors.gray900;
+          return theme.colors.gray700;
         case 'RESERVE_APPLIED':
-          return theme.colors.main700;
+          return theme.colors.main500;
         case 'RESERVED':
-          return theme.colors.gray300;
+          return theme.colors.gray100;
+      }
+    } else if (role === 'TRAINEE') {
+      switch ($status) {
+        case 'PAST':
+        case 'EMPTY':
+          return;
+        case 'OPEN':
+          return theme.colors.main500;
+        case 'RESERVE_APPLIED':
+          return theme.colors.gray100;
+        case 'RESERVED':
+          return theme.colors.gray100;
+      }
+    }
+  }};
+  color: ${({ theme, $status, role }) => {
+    if (role === 'TRAINER') {
+      switch ($status) {
+        case 'PAST':
+          return;
+        case 'EMPTY':
+        case 'OPEN':
+        case 'RESERVE_APPLIED':
+          return theme.colors.white;
+        case 'RESERVED':
+          return theme.colors.gray600;
+      }
+    } else if (role === 'TRAINEE') {
+      switch ($status) {
+        case 'PAST':
+        case 'EMPTY':
+          return;
+        case 'OPEN':
+          return theme.colors.white;
+        case 'RESERVE_APPLIED':
+        case 'RESERVED':
+          return theme.colors.gray600;
+      }
+    }
+  }};
+  border: ${({ theme, $status, role }) => {
+    if (role === 'TRAINER') {
+      switch ($status) {
+        case 'PAST':
+          return;
+        case 'EMPTY':
+        case 'OPEN':
+        case 'RESERVE_APPLIED':
+          return 'none';
+        case 'RESERVED':
+          return `1px solid ${theme.colors.gray300}`;
+      }
+    } else if (role === 'TRAINEE') {
+      switch ($status) {
+        case 'PAST':
+        case 'EMPTY':
+          return;
+        case 'OPEN':
+          return 'none';
+        case 'RESERVE_APPLIED':
+        case 'RESERVED':
+          return `1px solid ${theme.colors.gray300}`;
+      }
+    }
+  }};
+
+  &:active {
+    background-color: ${({ theme, $status, role }) => {
+      if (role === 'TRAINER') {
+        switch ($status) {
+          case 'PAST':
+            return;
+          case 'EMPTY':
+            return theme.colors.main700;
+          case 'OPEN':
+            return theme.colors.gray900;
+          case 'RESERVE_APPLIED':
+            return theme.colors.main700;
+          case 'RESERVED':
+            return theme.colors.gray300;
+        }
+      } else if (role === 'TRAINEE') {
+        switch ($status) {
+          case 'PAST':
+          case 'EMPTY':
+            return;
+          case 'OPEN':
+            return theme.colors.main700;
+          case 'RESERVE_APPLIED':
+          case 'RESERVED':
+            return theme.colors.gray300;
+        }
       }
     }};
     color: ${({ theme }) => theme.colors.white};
@@ -222,6 +276,7 @@ interface ScheduleDetailProps {
 }
 
 const ScheduleDetail: React.FC<ScheduleDetailProps> = ({ selectedDate }) => {
+  const { user } = useUserStore();
   const navigate = useNavigate();
   const AppointmentApi = CreateAppointmentApi(navigate);
   const { openModal, closeModal, isOpen } = useModals();
@@ -299,17 +354,30 @@ const ScheduleDetail: React.FC<ScheduleDetailProps> = ({ selectedDate }) => {
   };
 
   const getButtonText = ($status: ScheduleStatus) => {
-    switch ($status) {
-      case 'PAST':
-        return;
-      case 'EMPTY':
-        return '오픈';
-      case 'OPEN':
-        return '닫기';
-      case 'RESERVE_APPLIED':
-        return '확정';
-      case 'RESERVED':
-        return '취소';
+    if (user?.role === 'TRAINER') {
+      switch ($status) {
+        case 'PAST':
+          return;
+        case 'EMPTY':
+          return '오픈';
+        case 'OPEN':
+          return '닫기';
+        case 'RESERVE_APPLIED':
+          return '확정';
+        case 'RESERVED':
+          return '취소';
+      }
+    } else if (user?.role === 'TRAINEE') {
+      switch ($status) {
+        case 'PAST':
+        case 'EMPTY':
+          return;
+        case 'OPEN':
+          return '신청';
+        case 'RESERVE_APPLIED':
+        case 'RESERVED':
+          return '취소';
+      }
     }
   };
 
@@ -377,26 +445,33 @@ const ScheduleDetail: React.FC<ScheduleDetailProps> = ({ selectedDate }) => {
               </TimeBox>
               <InfoBox $status={$status}>
                 <Detail $status={$status}>{detailText}</Detail>
-                {$status !== 'PAST' && (
-                  <ButtonBox>
-                    <StatusButton
-                      $status={$status}
-                      onClick={() =>
-                        handleModal($status, 'open', scheduleId, time.shortTime)
-                      }
-                    >
-                      {getButtonText($status)}
-                    </StatusButton>
-                    {$status === 'RESERVE_APPLIED' && (
-                      <RejectButton
+                {$status !== 'PAST' &&
+                  !(user?.role === 'TRAINEE' && $status === 'EMPTY') && (
+                    <ButtonBox>
+                      <StatusButton
                         $status={$status}
-                        onClick={() => openModal('rejectModal')}
+                        role={user?.role}
+                        onClick={() =>
+                          handleModal(
+                            $status,
+                            'open',
+                            scheduleId,
+                            time.shortTime
+                          )
+                        }
                       >
-                        거절
-                      </RejectButton>
-                    )}
-                  </ButtonBox>
-                )}
+                        {getButtonText($status)}
+                      </StatusButton>
+                      {$status === 'RESERVE_APPLIED' && (
+                        <RejectButton
+                          $status={$status}
+                          onClick={() => openModal('rejectModal')}
+                        >
+                          거절
+                        </RejectButton>
+                      )}
+                    </ButtonBox>
+                  )}
               </InfoBox>
             </ScheduleTable>
           );

--- a/src/components/Appointment/ScheduleDetail.tsx
+++ b/src/components/Appointment/ScheduleDetail.tsx
@@ -50,7 +50,7 @@ const InfoBox = styled.div<{
   align-items: center;
   justify-content: space-between;
   flex: 1;
-  height: 60px;
+  height: 50px;
   padding: 0 10px;
   border-radius: 5px;
   border: 1px solid
@@ -98,15 +98,19 @@ const Detail = styled.span<{
   }};
 `;
 
-const ButtonBox = styled.div`
+const ButtonBox = styled.div<{ role?: string }>`
   display: flex;
   justify-content: right;
   gap: 10px;
   width: 170px;
 
-  @media (max-width: 410px) {
-    width: auto;
-  }
+  ${({ role }) =>
+    role === 'TRAINER' &&
+    `
+    @media (max-width: 410px) {
+      width: auto;
+    }
+  `}
 `;
 
 const StatusButton = styled.button<{ $status: ScheduleStatus; role?: string }>`
@@ -115,7 +119,7 @@ const StatusButton = styled.button<{ $status: ScheduleStatus; role?: string }>`
   justify-content: center;
   padding: 8px;
   border-radius: 0.5rem;
-  font-size: 1.6rem;
+  font-size: 1.4rem;
   cursor: pointer;
   width: 100%;
   max-width: 80px;
@@ -520,7 +524,7 @@ const ScheduleDetail: React.FC<ScheduleDetailProps> = ({ selectedDate }) => {
                 <Detail $status={$status}>{detailText}</Detail>
                 {$status !== 'PAST' &&
                   !(user?.role === 'TRAINEE' && $status === 'EMPTY') && (
-                    <ButtonBox>
+                    <ButtonBox role={user?.role}>
                       <StatusButton
                         $status={$status}
                         role={user?.role}

--- a/src/components/Appointment/ScheduleDetail.tsx
+++ b/src/components/Appointment/ScheduleDetail.tsx
@@ -571,14 +571,16 @@ const ScheduleDetail: React.FC<ScheduleDetailProps> = ({ selectedDate }) => {
         선택한 시간에 수업을 오픈할까요?
       </Modal>
       <Modal
-        title="수업일 닫기"
+        title={user?.role === 'TRAINER' ? '수업일 닫기' : '수업 신청'}
         type="confirm"
         isOpen={isOpen('closeModal')}
         onClose={() => handleModal('OPEN', 'close')}
         onSave={() => handleModal('OPEN', 'save')}
         btnConfirm="저장"
       >
-        선택한 시간에 수업을 닫을까요?
+        {user?.role === 'TRAINER'
+          ? '선택한 시간에 수업을 닫을까요?'
+          : '선택한 시간에 수업을 신청할까요?'}
       </Modal>
       <Modal
         title="수업 취소"
@@ -591,14 +593,16 @@ const ScheduleDetail: React.FC<ScheduleDetailProps> = ({ selectedDate }) => {
         선택한 시간에 수업을 취소할까요?
       </Modal>
       <Modal
-        title="수업 확정"
+        title={user?.role === 'TRAINER' ? '수업 확정' : '수업 신청 취소'}
         type="confirm"
         isOpen={isOpen('confirmModal')}
         onClose={() => handleModal('RESERVE_APPLIED', 'close')}
         onSave={() => handleModal('RESERVE_APPLIED', 'save')}
         btnConfirm="저장"
       >
-        선택한 시간에 수업을 확정할까요?
+        {user?.role === 'TRAINER'
+          ? '선택한 시간에 수업을 확정할까요?'
+          : '아직 확정되지 않은 수업입니다. 수업 신청을 취소할까요?'}
       </Modal>
       <Modal
         title="수업 거절"

--- a/src/components/Appointment/TimeTableContainer.tsx
+++ b/src/components/Appointment/TimeTableContainer.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
+import { format, isBefore, parse } from 'date-fns';
 
 import { generateTimes } from 'src/utils/generateTimes';
 import { hexToRgba } from 'src/utils/hexToRgba';
@@ -113,20 +114,43 @@ const TimeTableContainer: React.FC<TimeTableContainerProps> = ({
   onTimeClick,
 }) => {
   const times = generateTimes();
+  const today = format(new Date(), 'yyyy-MM-dd');
+
+  const isTimeDisabled = (
+    selectedButton: string | null,
+    selectedDates: string[],
+    reservedAndAppliedDates: { startDate: string; notAllowedTimes: string[] }[],
+    time: string,
+    today: string
+  ) => {
+    return (
+      selectedButton === 'register' &&
+      selectedDates.some(selectedDate => {
+        const reserved = reservedAndAppliedDates.find(
+          date => date.startDate === selectedDate
+        );
+        return (
+          reserved?.notAllowedTimes.includes(time) ||
+          (selectedDate === today &&
+            isBefore(parse(time, 'HH:mm', new Date()), new Date()))
+        );
+      })
+    );
+  };
 
   return (
     <Wrapper>
       <Text>선택 가능 시간</Text>
       <TimeTable>
         {times.map((time, index) => {
-          const isDisabled =
-            selectedButton === 'register' &&
-            selectedDates.some(selectedDate => {
-              const reserved = reservedAndAppliedDates.find(
-                date => date.startDate === selectedDate
-              );
-              return reserved?.notAllowedTimes.includes(time.shortTime);
-            });
+          const isDisabled = isTimeDisabled(
+            selectedButton,
+            selectedDates,
+            reservedAndAppliedDates,
+            time.shortTime,
+            today
+          );
+
           const isSelected = selectedTimes.includes(time.shortTime);
 
           return (

--- a/src/components/Appointment/TraineeRegisterModal.tsx
+++ b/src/components/Appointment/TraineeRegisterModal.tsx
@@ -109,7 +109,7 @@ const TraineeRegisterModal: React.FC<TraineeRegisterModalProps> = ({
 
   const onClickTrainee = (trainee: TraineeDataType) => {
     if (trainee.remainingSession === 0) {
-      setErrorAlert('잔여 횟수가 없습니다.');
+      setErrorAlert('남은 PT 횟수가 부족합니다.');
       return;
     }
 

--- a/src/components/Appointment/WeeklyCalendar.tsx
+++ b/src/components/Appointment/WeeklyCalendar.tsx
@@ -122,7 +122,7 @@ const WeeklyCalendar: React.FC<WeeklyCalendarProps> = ({
   const onWheelScroll = (e: WheelEvent) => {
     if (calendarRef.current) {
       e.preventDefault();
-      calendarRef.current.scrollLeft += e.deltaY;
+      calendarRef.current.scrollLeft += e.deltaY + e.deltaX;
     }
   };
 

--- a/src/mocks/data/scheduleList.ts
+++ b/src/mocks/data/scheduleList.ts
@@ -1,25 +1,4 @@
-export type ScheduleStatus =
-  | 'PAST'
-  | 'EMPTY'
-  | 'OPEN'
-  | 'RESERVE_APPLIED'
-  | 'RESERVED';
-
-export interface ScheduleDetailType {
-  scheduleId: number;
-  startTime: string;
-  trainerId: number;
-  trainerName: string;
-  traineeId: number | null;
-  traineeName: string | null;
-  status: ScheduleStatus;
-}
-
-export interface ScheduleType {
-  startDate: string;
-  existReserved: boolean;
-  details: ScheduleDetailType[];
-}
+import { ScheduleType } from '@components/Appointment/ScheduleDetail';
 
 export const scheduleList: ScheduleType[] = [
   {
@@ -33,7 +12,7 @@ export const scheduleList: ScheduleType[] = [
         trainerName: '이근육',
         traineeId: null,
         traineeName: null,
-        status: 'OPEN',
+        scheduleStatus: 'OPEN',
       },
       {
         scheduleId: 13,
@@ -42,7 +21,7 @@ export const scheduleList: ScheduleType[] = [
         trainerName: '이근육',
         traineeId: 2,
         traineeName: '미나리',
-        status: 'RESERVED',
+        scheduleStatus: 'RESERVED',
       },
     ],
   },
@@ -57,7 +36,7 @@ export const scheduleList: ScheduleType[] = [
         trainerName: '이근육',
         traineeId: 2,
         traineeName: '미나리',
-        status: 'RESERVE_APPLIED',
+        scheduleStatus: 'RESERVE_APPLIED',
       },
     ],
   },
@@ -72,7 +51,7 @@ export const scheduleList: ScheduleType[] = [
         trainerName: '이근육',
         traineeId: 1,
         traineeName: '김열심',
-        status: 'RESERVED',
+        scheduleStatus: 'RESERVED',
       },
       {
         scheduleId: 16,
@@ -81,7 +60,7 @@ export const scheduleList: ScheduleType[] = [
         trainerName: '이근육',
         traineeId: 2,
         traineeName: '미나리',
-        status: 'RESERVED',
+        scheduleStatus: 'RESERVED',
       },
       {
         scheduleId: 17,
@@ -90,7 +69,7 @@ export const scheduleList: ScheduleType[] = [
         trainerName: '이근육',
         traineeId: null,
         traineeName: null,
-        status: 'OPEN',
+        scheduleStatus: 'OPEN',
       },
       {
         scheduleId: 18,
@@ -99,7 +78,7 @@ export const scheduleList: ScheduleType[] = [
         trainerName: '이근육',
         traineeId: 2,
         traineeName: '미나리',
-        status: 'RESERVE_APPLIED',
+        scheduleStatus: 'RESERVE_APPLIED',
       },
       {
         scheduleId: 19,
@@ -108,7 +87,7 @@ export const scheduleList: ScheduleType[] = [
         trainerName: '이근육',
         traineeId: 2,
         traineeName: '미나리',
-        status: 'RESERVED',
+        scheduleStatus: 'RESERVED',
       },
     ],
   },

--- a/src/pages/Appointment/MonthlyContent.tsx
+++ b/src/pages/Appointment/MonthlyContent.tsx
@@ -189,10 +189,12 @@ const MonthlyContent: React.FC = () => {
       ) => {
         const merged = [...combinedReservedAndAppliedDates];
         newDates.forEach(newDate => {
-          const exists = merged.some(
+          const index = merged.findIndex(
             existingDate => existingDate.startDate === newDate.startDate
           );
-          if (!exists) {
+          if (index !== -1) {
+            merged[index] = newDate;
+          } else {
             merged.push(newDate);
           }
         });

--- a/src/pages/Appointment/WeeklyContent.tsx
+++ b/src/pages/Appointment/WeeklyContent.tsx
@@ -6,6 +6,7 @@ import { format, parse } from 'date-fns';
 import WeeklyCalendar from '@components/Appointment/WeeklyCalendar';
 import ScheduleDetail from '@components/Appointment/ScheduleDetail';
 import { SectionWrapper } from '@components/Common/SectionWrapper';
+import useCalendarStore from 'src/stores/calendarStore';
 
 const Wrapper = styled.div`
   display: flex;
@@ -16,11 +17,13 @@ const Wrapper = styled.div`
 const WeeklyContent: React.FC = () => {
   const { date } = useParams<{ date: string }>();
   const navigate = useNavigate();
+  const { setSelectedDate } = useCalendarStore();
   const initialDate = date ? parse(date, 'yyyy-MM-dd', new Date()) : new Date();
-  const [selectedDate, setSelectedDate] = useState<Date>(initialDate);
+  const [currentDate, setCurrentDate] = useState<Date>(initialDate);
 
   const onDateChange = (date: Date) => {
     setSelectedDate(date);
+    setCurrentDate(date);
 
     const formattedDate = format(date, 'yyyy-MM-dd');
     navigate(`/appointment/weekly/${formattedDate}`, { replace: true });
@@ -30,10 +33,10 @@ const WeeklyContent: React.FC = () => {
     <SectionWrapper>
       <Wrapper>
         <WeeklyCalendar
-          selectedDate={selectedDate}
+          selectedDate={currentDate}
           onDateChange={onDateChange}
         />
-        <ScheduleDetail selectedDate={selectedDate} />
+        <ScheduleDetail selectedDate={currentDate} />
       </Wrapper>
     </SectionWrapper>
   );


### PR DESCRIPTION
### 📝 관련 이슈
closed #70 

### ✨ 반영 브랜치
- FROM: `70-feat/appointment-weekly-api`
- TO: `master`

### ✅ PR 내용

### 주별 시간표 상세 조회
- [x] 트레이너의 일정 조회 API 연동
- [x] 트레이니의 일정 조회 API 연동
> - startTime과 endTime을 주별 시간표에서 선택된 특정 날짜로 요청하여 05:00 ~ 23:00 까지의 세부 일정을 응답받음
> - 트레이너가 조회 시 계약된 모든 트레이니의 일정을 함께 표시, 트레이니가 조회 시 본인의 일정과 트레이너의 OPEN 상태 일정 표시
> - 주별 시간표에서 특정 날짜를 클릭해서 본 후 월별 시간표로 돌아가면 특정 날짜가 있는 달로 이동 (useCalendarStore 사용)
> - 트레이너, 트레이니에 따라 버튼의 텍스트, 디자인이 구분되고 모달의 내용과 onClick 이벤트핸들러도 분리

### 주별 시간표 버튼 동작
- [x] 트레이너의 일정 열기 API 연동
- [x] 트레이너의 일정 닫기 API 연동
- [x] 트레이너의 일정 수락 API 연동
- [x] 트레이너의 일정 거절 API 연동
- [x] 트레이너의 일정 취소 API 연동
- [x] 트레이니의 일정 신청 API 연동
- [x] 트레이니의 일정 취소 API 연동
> - 주별 시간표 내 버튼(오픈, 닫기, 확정, 신청, 신청취소, 취소)을 클릭하면 모달로 연결되고 모든 모달을 handleModal 함수로 관리 
> - 유일하게 하나의 일정에 두개의 버튼이 나오는 경우가 일정이 RESERVE_APPLIED일 때 트레이너가 보는 화면에서 확정과 거절 버튼이 나오므로 거절 버튼을 따로 핸들링하는 handleRejectModal 함수 추가
> - handleModal에서는 일정의 status와 action을 받아서 유저 role에 따라 알맞은 API 요청으로 연결 (handleTrainerActions, handleTraineeActions으로 추가 분리)
> - 에러도 한 곳에서 관리하도록 handleError 함수 추가. 이후 서버 에러 핸들링이 추가되면 해당 함수에 추가.

### BUG FIX
- [x] 월별 시간표 조회 시 현재 날짜는 border CSS를 추가하여 표시
- [x] 주별 시간표의 calendar 영역에서 트랙패드로 가로스크롤시 스크롤이 잘 되지 않는 문제 수정
- [x] 월별 시간표 탭 > 수업 일괄 등록 기능에서 오늘 날짜도 일괄 등록 가능하도록 수정

### 🌐 테스트 배포
- [x] 테스트 배포하여 잘 동작하는 지 확인했나요?
> - 테스트 배포 주소: https://sm.training-diary.co.kr
> - 테스트 환경 (Desktop): MacOS (Chrome / Safari / Firefox / Edge)
> - 테스트 환경 (Mobile): Android (Chrome / 삼성인터넷)
