### PR TITLE
[FEAT] 트레이니 홈 > 운동 기록 탭 API 연동 #71

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -36,6 +36,7 @@
     "Neue",
     "Noto",
     "nwtgck",
+    "pageable",
     "Parens",
     "Roboto",
     "scrollgrid",

--- a/src/api/trainee.ts
+++ b/src/api/trainee.ts
@@ -34,8 +34,6 @@ const CreateTraineeApi = (navigate: NavigateFunction) => {
 
     addSession: (sessionData: SessionDataType) =>
       axiosInstance.post('workout-sessions', sessionData),
-
-    detailWorkouts: (id: number) => axiosInstance.get(`/workout-types/${id}`),
   };
 };
 

--- a/src/api/trainee.ts
+++ b/src/api/trainee.ts
@@ -12,6 +12,7 @@ const CreateTraineeApi = (navigate: NavigateFunction) => {
   }
 
   return {
+    // dashboard
     getTraineeInfo: (id: string | undefined) =>
       axiosInstance.get(`trainers/trainees/${id}`),
 
@@ -20,6 +21,15 @@ const CreateTraineeApi = (navigate: NavigateFunction) => {
 
     addInbodyInfo: (inbodyData: AddInbodyData) =>
       axiosInstance.post('trainers/trainees', inbodyData),
+
+    //session
+    getSessionsList: (id: string | undefined, page: number, size: number) =>
+      axiosInstance.get(`workout-sessions/trainees/${id}`, {
+        params: {
+          page,
+          size,
+        },
+      }),
   };
 };
 

--- a/src/api/trainee.ts
+++ b/src/api/trainee.ts
@@ -34,6 +34,8 @@ const CreateTraineeApi = (navigate: NavigateFunction) => {
 
     addSession: (sessionData: SessionDataType) =>
       axiosInstance.post('workout-sessions', sessionData),
+
+    detailWorkouts: (id: number) => axiosInstance.get(`/workout-types/${id}`),
   };
 };
 

--- a/src/api/trainee.ts
+++ b/src/api/trainee.ts
@@ -2,6 +2,7 @@ import { NavigateFunction } from 'react-router-dom';
 
 import { axiosInstance, createInterceptor } from './axiosInstance';
 import { AddInbodyData, TraineeInfoData } from '@pages/Trainee/Dashboard';
+import { SessionDataType } from '@components/Trainee/AddSessionModal';
 
 let isInterceptorCreated = false;
 
@@ -30,6 +31,9 @@ const CreateTraineeApi = (navigate: NavigateFunction) => {
           size,
         },
       }),
+
+    addSession: (sessionData: SessionDataType) =>
+      axiosInstance.post('workout-sessions', sessionData),
   };
 };
 

--- a/src/api/trainee.ts
+++ b/src/api/trainee.ts
@@ -24,7 +24,7 @@ const CreateTraineeApi = (navigate: NavigateFunction) => {
       axiosInstance.post('trainers/trainees', inbodyData),
 
     //session
-    getSessionsList: (id: string | undefined, page: number, size: number) =>
+    getSessionsList: (id: string | undefined, page?: number, size?: number) =>
       axiosInstance.get(`workout-sessions/trainees/${id}`, {
         params: {
           page,

--- a/src/api/trainer.ts
+++ b/src/api/trainer.ts
@@ -30,7 +30,7 @@ const CreateTrainerApi = (navigate: NavigateFunction) => {
     deleteTrainee: (ptContractId: number) =>
       axiosInstance.post('/pt-contracts/terminate', { ptContractId }),
 
-    getWorkouts: (page: number, size: number) =>
+    getWorkouts: (page?: number, size?: number) =>
       axiosInstance.get('/workout-types', {
         params: {
           page,

--- a/src/components/Trainee/AddSessionModal.tsx
+++ b/src/components/Trainee/AddSessionModal.tsx
@@ -32,6 +32,14 @@ const FormGroup = styled.div`
     top: 110% !important;
   }
 
+  .react-datepicker__navigation {
+    top: 15px;
+
+    .react-datepicker__navigation-icon::before {
+      border-color: ${({ theme }) => theme.colors.white};
+    }
+  }
+
   .react-datepicker-popper[data-placement^='bottom']
     .react-datepicker__triangle {
     left: 10% !important;
@@ -42,6 +50,13 @@ const FormGroup = styled.div`
 
   h2.react-datepicker__current-month {
     font-size: 1.5rem;
+    color: ${({ theme }) => theme.colors.white};
+    padding: 10px;
+  }
+
+  .react-datepicker__day-name {
+    color: ${({ theme }) => theme.colors.white};
+    font-family: 'NanumSquareBold';
   }
 `;
 

--- a/src/components/Trainee/AddSessionModal.tsx
+++ b/src/components/Trainee/AddSessionModal.tsx
@@ -374,9 +374,13 @@ const AddSessionModal: React.FC<AddSessionModalProps> = ({
       onSave(formData);
       setFormState(initialFormState);
       onClose();
-    } catch (error) {
+    } catch (error: any) {
+      if (error.response.status === 409) {
+        setErrorAlert('이미 존재하는 회차입니다.');
+      } else {
+        setErrorAlert('운동 기록 생성에 실패했습니다.');
+      }
       console.error('운동 기록 생성 실패:', error);
-      setErrorAlert('운동 기록 생성에 실패했습니다.');
     }
   };
 

--- a/src/components/Trainee/AddSessionModal.tsx
+++ b/src/components/Trainee/AddSessionModal.tsx
@@ -331,6 +331,10 @@ const AddSessionModal: React.FC<AddSessionModalProps> = ({
     if (formState.specialNote.trim() === '')
       return setErrorAlert('특이사항을 입력해주세요.');
 
+    if (formState.workouts.length === 0) {
+      return setErrorAlert('운동 종류를 하나 이상 선택해주세요.');
+    }
+
     // 운동 종류 기록 유효성 검사 로직
     for (let i = 0; i < formState.workouts.length; i++) {
       const workout = formState.workouts[i];

--- a/src/components/Trainee/AddSessionModal.tsx
+++ b/src/components/Trainee/AddSessionModal.tsx
@@ -6,8 +6,8 @@ import 'react-datepicker/dist/react-datepicker.css';
 import Modal from '@components/Common/Modal/Modal';
 import Alert from '@components/Common/Alert/Alert';
 import { DatePickerWrapper } from './Calendar';
-import { useNavigate } from 'react-router-dom';
 import CreateTraineeApi from 'src/api/trainee';
+import { useNavigate } from 'react-router-dom';
 
 const FormGroup = styled.div`
   display: flex;
@@ -257,7 +257,7 @@ const AddSessionModal: React.FC<AddSessionModalProps> = ({
 
   const [errorAlert, setErrorAlert] = useState<string>('');
 
-  const handleSave = () => {
+  const handleSave = async () => {
     if (formState.sessionDate === null)
       return setErrorAlert('날짜를 입력해주세요.');
 
@@ -293,9 +293,17 @@ const AddSessionModal: React.FC<AddSessionModalProps> = ({
       }
     }
 
-    onSave(formState);
-    setFormState(initialFormState);
-    onClose();
+    // 운동 기록 생성 API 호출
+    try {
+      const response = await traineeApi.addSession(formState);
+      console.log('운동 기록 생성 성공:', response.data);
+      onSave(formState);
+      setFormState(initialFormState);
+      onClose();
+    } catch (error) {
+      console.error('운동 기록 생성 실패:', error);
+      setErrorAlert('운동 기록 생성에 실패했습니다.');
+    }
   };
 
   const handleClose = () => {

--- a/src/components/Trainee/AddSessionModal.tsx
+++ b/src/components/Trainee/AddSessionModal.tsx
@@ -6,6 +6,8 @@ import 'react-datepicker/dist/react-datepicker.css';
 import Modal from '@components/Common/Modal/Modal';
 import Alert from '@components/Common/Alert/Alert';
 import { DatePickerWrapper } from './Calendar';
+import { useNavigate } from 'react-router-dom';
+import CreateTraineeApi from 'src/api/trainee';
 
 const FormGroup = styled.div`
   display: flex;
@@ -144,6 +146,7 @@ export interface WorkoutsType {
 }
 
 export interface SessionDataType {
+  traineeId: string | undefined;
   sessionDate: Date | null;
   sessionNumber: number;
   specialNote: string;
@@ -151,6 +154,7 @@ export interface SessionDataType {
 }
 
 interface AddSessionModalProps {
+  traineeId: string | undefined;
   isOpen: boolean;
   onClose: () => void;
   onSave: (session: SessionDataType) => void;
@@ -174,8 +178,13 @@ const AddSessionModal: React.FC<AddSessionModalProps> = ({
   formState,
   setFormState,
   workoutTypes,
+  traineeId,
 }) => {
+  const navigate = useNavigate();
+  const traineeApi = CreateTraineeApi(navigate);
+
   const initialFormState: SessionDataType = {
+    traineeId: traineeId,
     sessionDate: new Date() || null,
     sessionNumber: 0,
     specialNote: '',

--- a/src/components/Trainee/AddSessionModal.tsx
+++ b/src/components/Trainee/AddSessionModal.tsx
@@ -193,6 +193,7 @@ interface AddSessionModalProps {
   onSave: (session: SessionDataType) => void;
   formState: SessionDataType;
   setFormState: React.Dispatch<React.SetStateAction<SessionDataType>>;
+  sessionAutoNumber: number;
 }
 
 const AddSessionModal: React.FC<AddSessionModalProps> = ({
@@ -202,6 +203,7 @@ const AddSessionModal: React.FC<AddSessionModalProps> = ({
   formState,
   setFormState,
   traineeId,
+  sessionAutoNumber,
 }) => {
   const navigate = useNavigate();
   const traineeApi = CreateTraineeApi(navigate);
@@ -222,7 +224,7 @@ const AddSessionModal: React.FC<AddSessionModalProps> = ({
   const initialFormState: SessionDataType = {
     traineeId: traineeId,
     sessionDate: format(new Date(), 'yyyy-MM-dd'),
-    sessionNumber: 0,
+    sessionNumber: sessionAutoNumber,
     specialNote: '',
     workouts: [
       {

--- a/src/pages/Trainee/Session.tsx
+++ b/src/pages/Trainee/Session.tsx
@@ -112,7 +112,7 @@ const Session: React.FC = () => {
       { type: '', weight: '', speed: '', time: '', sets: '', rep: '' },
     ],
   });
-  const [workoutTypes, setWorkoutTypes] = useState<
+  const [workoutTypes] = useState<
     {
       id: number;
       name: string;
@@ -129,10 +129,13 @@ const Session: React.FC = () => {
     return res.data;
   };
 
-  const { data, fetchNextPage, hasNextPage, isFetchingNextPage, status } =
-    useInfiniteQuery('sessions', fetchSessions, {
-      getNextPageParam: (lastPage, allPages) => lastPage.nextPage ?? false,
-    });
+  const { data, fetchNextPage, hasNextPage } = useInfiniteQuery(
+    'sessions',
+    fetchSessions,
+    {
+      getNextPageParam: lastPage => lastPage.nextPage ?? false,
+    }
+  );
 
   const sessions = data?.pages.flatMap(page => page.content) ?? [];
   const images = sessions.flatMap((session: SessionData) =>

--- a/src/pages/Trainee/Session.tsx
+++ b/src/pages/Trainee/Session.tsx
@@ -104,6 +104,7 @@ const Session: React.FC = () => {
   const scrollLeftRef = useRef(0);
   const { openModal, closeModal, isOpen } = useModals();
   const [formState, setFormState] = useState<SessionDataType>({
+    traineeId: traineeId,
     sessionDate: new Date(),
     sessionNumber: 0,
     specialNote: '',
@@ -285,6 +286,7 @@ const Session: React.FC = () => {
         formState={formState}
         setFormState={setFormState}
         workoutTypes={workoutTypes}
+        traineeId={traineeId}
       />
     </SectionWrapper>
   );

--- a/src/pages/Trainee/Session.tsx
+++ b/src/pages/Trainee/Session.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useRef } from 'react';
 import styled from 'styled-components';
 import { Link, useNavigate, useParams } from 'react-router-dom';
 import { useInfiniteQuery } from 'react-query';
+import { format } from 'date-fns';
 
 import addBtn from '@icons/home/addbtn.svg';
 import { SectionWrapper } from '@components/Common/SectionWrapper';
@@ -105,31 +106,20 @@ const Session: React.FC = () => {
   const { openModal, closeModal, isOpen } = useModals();
   const [formState, setFormState] = useState<SessionDataType>({
     traineeId: traineeId,
-    sessionDate: new Date(),
+    sessionDate: format(new Date(), 'yyyy-MM-dd'),
     sessionNumber: 0,
     specialNote: '',
     workouts: [
-      { type: '', weight: '', speed: '', time: '', sets: '', rep: '' },
+      { workoutTypeId: 0, weight: '', speed: '', time: '', sets: '', rep: '' },
     ],
   });
-  const [workoutTypes] = useState<
-    {
-      id: number;
-      name: string;
-      weightInputRequired: boolean;
-      setInputRequired: boolean;
-      repInputRequired: boolean;
-      timeInputRequired: boolean;
-      speedInputRequired: boolean;
-    }[]
-  >([]);
 
   const fetchSessions = async ({ pageParam = 0 }) => {
     const res = await traineeApi.getSessionsList(traineeId, pageParam, 20);
     return res.data;
   };
 
-  const { data, fetchNextPage, hasNextPage } = useInfiniteQuery(
+  const { data, fetchNextPage, hasNextPage, refetch } = useInfiniteQuery(
     'sessions',
     fetchSessions,
     {
@@ -237,9 +227,8 @@ const Session: React.FC = () => {
     };
   }, []);
 
-  const handleSaveSession = (session: SessionDataType) => {
-    console.log(session);
-    // Handle the save logic
+  const handleSaveSession = () => {
+    refetch();
   };
 
   const handleImageClick = (sessionId: number) => {
@@ -288,7 +277,6 @@ const Session: React.FC = () => {
         onSave={handleSaveSession}
         formState={formState}
         setFormState={setFormState}
-        workoutTypes={workoutTypes}
         traineeId={traineeId}
       />
     </SectionWrapper>

--- a/src/pages/Trainee/Session.tsx
+++ b/src/pages/Trainee/Session.tsx
@@ -104,15 +104,6 @@ const Session: React.FC = () => {
   const startXRef = useRef(0);
   const scrollLeftRef = useRef(0);
   const { openModal, closeModal, isOpen } = useModals();
-  const [formState, setFormState] = useState<SessionDataType>({
-    traineeId: traineeId,
-    sessionDate: format(new Date(), 'yyyy-MM-dd'),
-    sessionNumber: 0,
-    specialNote: '',
-    workouts: [
-      { workoutTypeId: 0, weight: '', speed: '', time: '', sets: '', rep: '' },
-    ],
-  });
 
   const fetchSessions = async ({ pageParam = 0 }) => {
     const res = await traineeApi.getSessionsList(traineeId, pageParam, 20);
@@ -134,6 +125,16 @@ const Session: React.FC = () => {
       sessionId: session.sessionId,
     }))
   );
+
+  const [formState, setFormState] = useState<SessionDataType>({
+    traineeId: traineeId,
+    sessionDate: format(new Date(), 'yyyy-MM-dd'),
+    sessionNumber: sessions.length + 1,
+    specialNote: '',
+    workouts: [
+      { workoutTypeId: 0, weight: '', speed: '', time: '', sets: '', rep: '' },
+    ],
+  });
 
   useEffect(() => {
     const observer = new IntersectionObserver(
@@ -231,8 +232,17 @@ const Session: React.FC = () => {
     refetch();
   };
 
+  const handleOpenModal = async () => {
+    await refetch(); // 모달을 열기 전에 세션 목록을 다시 로드
+    setFormState({
+      ...formState,
+      sessionNumber: sessions.length + 1,
+    });
+    openModal('addSessionModal');
+  };
+
   const handleImageClick = (sessionId: number) => {
-    navigate(`/trainee/${traineeId}/session/${sessionId}`); // traineeID
+    navigate(`/trainee/${traineeId}/session/${sessionId}`);
   };
 
   return (
@@ -267,7 +277,7 @@ const Session: React.FC = () => {
         </RecordBox>
       </Wrapper>
       {user?.role === 'TRAINER' ? (
-        <AddButton onClick={() => openModal('addSessionModal')}>
+        <AddButton onClick={handleOpenModal}>
           <img src={addBtn} alt="add button" />
         </AddButton>
       ) : null}
@@ -278,6 +288,7 @@ const Session: React.FC = () => {
         formState={formState}
         setFormState={setFormState}
         traineeId={traineeId}
+        sessionAutoNumber={sessions.length + 1}
       />
     </SectionWrapper>
   );

--- a/src/pages/Trainee/Session.tsx
+++ b/src/pages/Trainee/Session.tsx
@@ -137,7 +137,7 @@ const Session: React.FC = () => {
   const [formState, setFormState] = useState<SessionDataType>({
     traineeId: traineeId,
     sessionDate: format(new Date(), 'yyyy-MM-dd'),
-    sessionNumber: totalElements,
+    sessionNumber: totalElements + 1,
     specialNote: '',
     workouts: [
       { workoutTypeId: 0, weight: '', speed: '', time: '', sets: '', rep: '' },
@@ -269,7 +269,7 @@ const Session: React.FC = () => {
     await refetch(); // 모달을 열기 전에 세션 목록을 다시 로드
     setFormState({
       ...formState,
-      sessionNumber: sessions.length + 1,
+      sessionNumber: totalElements + 1,
     });
     openModal('addSessionModal');
   };
@@ -284,28 +284,62 @@ const Session: React.FC = () => {
         <PhotoBox>
           <SectionTitle>자세 사진 목록</SectionTitle>
           <ImageContainer ref={imageContainerRef}>
-            {images.map((image, index) => (
-              <ImageLayout
-                key={index}
-                onClick={() => handleImageClick(image.sessionId)}
+            {images.length > 0 ? (
+              images.map((image, index) => (
+                <ImageLayout
+                  key={index}
+                  onClick={() => handleImageClick(image.sessionId)}
+                >
+                  <Image
+                    src={image.src}
+                    alt={`image ${index}`}
+                    loading="lazy"
+                  />
+                </ImageLayout>
+              ))
+            ) : (
+              <div
+                style={{
+                  fontSize: '1.4rem',
+                  display: 'flex',
+                  justifyContent: 'center',
+                  width: '100%',
+                  minHeight: '150px',
+                  alignItems: 'center',
+                  marginLeft: '20px',
+                }}
               >
-                <Image src={image.src} alt={`image ${index}`} loading="lazy" />
-              </ImageLayout>
-            ))}
+                아직 자세 사진이 없습니다.
+              </div>
+            )}
             <div ref={imageObserverRef} />
           </ImageContainer>
         </PhotoBox>
         <RecordBox>
           <SectionTitle>운동 기록 목록</SectionTitle>
           <RecordList>
-            {sessions.map((session, index) => (
-              <Link to={`${session.sessionId}`} key={index}>
-                <RecordItem>
-                  <div>{session.sessionDate}</div>
-                  <div>{session.sessionNumber}회차</div>
-                </RecordItem>
-              </Link>
-            ))}
+            {sessions.length > 0 ? (
+              sessions.map((session, index) => (
+                <Link to={`${session.sessionId}`} key={index}>
+                  <RecordItem>
+                    <div>{session.sessionDate}</div>
+                    <div>{session.sessionNumber}회차</div>
+                  </RecordItem>
+                </Link>
+              ))
+            ) : (
+              <div
+                style={{
+                  fontSize: '1.4rem',
+                  display: 'flex',
+                  justifyContent: 'center',
+                  height: '50vh',
+                  alignItems: 'center',
+                }}
+              >
+                아직 운동 기록이 없습니다.
+              </div>
+            )}
             <div ref={listObserverRef} />
           </RecordList>
         </RecordBox>

--- a/src/pages/Trainee/Session.tsx
+++ b/src/pages/Trainee/Session.tsx
@@ -90,11 +90,6 @@ interface SessionData {
   thumbnailUrls: string[];
 }
 
-interface ImageWithSession {
-  src: string;
-  sessionId: number;
-}
-
 const Session: React.FC = () => {
   useFetchUser();
   const navigate = useNavigate();

--- a/src/styles/globalStyles.ts
+++ b/src/styles/globalStyles.ts
@@ -12,7 +12,7 @@ ${reset};
 
 
 
-//font-size base = 10px = 1rem / ex) 16px === 1.6rem 
+//font-size base = 10px = 1rem / ex) 16px === 1.6rem
 html, body{
   font-size: 10px;
   line-height: 1.5;
@@ -62,6 +62,14 @@ h1 {
 
 *::-webkit-scrollbar {
   display: none; /* Safari and Chrome */
+}
+
+.react-datepicker__day--keyboard-selected, .react-datepicker__month-text--keyboard-selected, .react-datepicker__quarter-text--keyboard-selected, .react-datepicker__year-text--keyboard-selected{
+  background-color: transparent;
+}
+
+.react-datepicker__day--keyboard-selected:hover, .react-datepicker__month-text--keyboard-selected:hover, .react-datepicker__quarter-text--keyboard-selected:hover, .react-datepicker__year-text--keyboard-selected:hover{
+  background-color: #f0f0f0;
 }
 
 // view width 450px 이상이 되면 max-width = 450px로 고정 / 그 이하는 추후 작업하며 조절 예정


### PR DESCRIPTION
### 📝 관련 이슈
closed #71 

### ✨ 반영 브랜치
<!-- 어떤 브랜치에서 어떤 브랜치로 merge하는지 적어주세요 -->
- FROM: `71-feat/trainee-workout-session-api`
- TO: `master`

### ✅ PR 내용
<!-- 기능마다 아래 템플릿으로 PR에 대한 설명을 적어주세요 (기능별 AS-IS, TO-BE, 변경이유 등) -->
- [x] 운동 일지 목록 조회 API 연동 운동 기록 목록 조회
> - 트레이니 ID와 페이지 정보를 받아 운동 일지 목록을 `조회`합니다. `무한스크롤`을 지원하기 위해 `useInfiniteQuery` 훅을 사용하고, `getNextPageParam` 옵션을 통해 다음 페이지를 결정합니다.
운동 일지의 총 개수를 `setTotalElements` 함수를 사용해 상태로 관리
```typescript
getSessionsList: (id: string | undefined, page: number, size: number) =>
      axiosInstance.get(`workout-sessions/trainees/${id}`, {
        params: {
          page,
          size,
        },
      }),
```

- [x] 운동 일지 생성 API 연동
> - 새로운 운동 일지를 생성하는 기능을 추가했습니다. 사용자가 입력한 데이터를 API를 통해 서버에 저장합니다.
운동 일지 생성 시 중복된 회차를 확인하여 중복되는 회차를 막기 위해 `setErrorAlert`로 사용자에게 알림을 표시합니다.
```typescript
addSession: (sessionData: SessionDataType) =>
      axiosInstance.post('workout-sessions', sessionData),
```

### 🌐 테스트 배포
<!-- 모바일 기기에서 진행한 테스트에 대해 적어주세요 -->
- [x] 테스트 배포하여 잘 동작하는 지 확인했나요?
> - 테스트 배포 주소: https://jm.training-diary.co.kr/
> - 테스트 환경 (Desktop): Windows(Chrome / Firefox / Edge)
> - 테스트 환경 (Mobile): ios (Safari)

### 📌 ETC
<!-- 레퍼런스, 참고할 사항, 질문 사항이 있다면 적어주세요 (Optional) -->
1. 사진 목록 조회는 테스트를 완벽히 하지 못해서 다음 작업에 PR을 올리도록 하겠습니다.
2. 제가 여쭤봤던 params string 값은 조금 더 찾아보고, 추후 리팩토링 하도록 하겠습니다.
3. 운동 기록 생성 시 중복된 회차를 확인하는 로직을 추가하여 중복되는 회차를 막아야 했습니다. 서버 쪽에서 한 회차는 하나만 등록할 수 있도록 작업 되었습니다.
4. 중복 회차를 막기 위해 매번 확인하기 불편할 듯 하여 자동으로 totalSession을 받아 초기 폼에 입력되게 했습니다.
5. 무한 스크롤 작업을 하느라 많이 늦어졌습니다.🥲 될 듯 말 듯 하여 포기하기가 어려웠습니다.