### PR TITLE
[FEAT] HOME > 식단관리 탭 API 연동 #64

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,6 @@
         "react-datepicker": "^7.3.0",
         "react-dom": "^18.3.1",
         "react-hook-form": "^7.52.1",
-        "react-infinite-scroll-component": "^6.1.0",
         "react-query": "^3.39.3",
         "react-router-dom": "^6.24.1",
         "react-toastify": "^10.0.5",
@@ -9207,17 +9206,6 @@
         "react": "^16.8.0 || ^17 || ^18 || ^19"
       }
     },
-    "node_modules/react-infinite-scroll-component": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/react-infinite-scroll-component/-/react-infinite-scroll-component-6.1.0.tgz",
-      "integrity": "sha512-SQu5nCqy8DxQWpnUVLx7V7b7LcA37aM7tvoWjTLZp1dk6EJibM5/4EJKzOnl07/BsM1Y40sKLuqjCwwH/xV0TQ==",
-      "dependencies": {
-        "throttle-debounce": "^2.1.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.0.0"
-      }
-    },
     "node_modules/react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
@@ -9912,14 +9900,6 @@
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true
-    },
-    "node_modules/throttle-debounce": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/throttle-debounce/-/throttle-debounce-2.3.0.tgz",
-      "integrity": "sha512-H7oLPV0P7+jgvrk+6mwwwBDmxTaxnu9HMXmloNLXwnNO0ZxZ31Orah2n8lU1eMPvsaowP2CX+USCgyovXfdOFQ==",
-      "engines": {
-        "node": ">=8"
-      }
     },
     "node_modules/tmpl": {
       "version": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "react-datepicker": "^7.3.0",
     "react-dom": "^18.3.1",
     "react-hook-form": "^7.52.1",
-    "react-infinite-scroll-component": "^6.1.0",
     "react-query": "^3.39.3",
     "react-router-dom": "^6.24.1",
     "react-toastify": "^10.0.5",

--- a/src/api/trainee.ts
+++ b/src/api/trainee.ts
@@ -46,6 +46,11 @@ const CreateTraineeApi = (navigate: NavigateFunction) => {
 
     addComment: (id: number, comment: string) =>
       axiosInstance.post('/comments/', { id, comment }),
+
+    editComment: (id: number, comment: string) =>
+      axiosInstance.put('/comments/', { id, comment }),
+
+    deleteComment: (id: number) => axiosInstance.delete(`/comments/${id}`),
   };
 };
 

--- a/src/api/trainee.ts
+++ b/src/api/trainee.ts
@@ -41,7 +41,7 @@ const CreateTraineeApi = (navigate: NavigateFunction) => {
       formData.append('image', image);
       formData.append('content', JSON.stringify(content));
 
-      return axiosInstance.post('/diets/', formData, {
+      return axiosInstance.post('/diets', formData, {
         headers: {
           'Content-Type': 'multipart/form-data',
         },
@@ -58,10 +58,10 @@ const CreateTraineeApi = (navigate: NavigateFunction) => {
     getDietDetail: (id: number) => axiosInstance.get(`/diets/${id}/details`),
 
     addComment: (id: number, comment: string) =>
-      axiosInstance.post('/comments/', { id, comment }),
+      axiosInstance.post('/comments', { id, comment }),
 
     editComment: (id: number, comment: string) =>
-      axiosInstance.put('/comments/', { id, comment }),
+      axiosInstance.put('/comments', { id, comment }),
 
     deleteComment: (id: number) => axiosInstance.delete(`/comments/${id}`),
   };

--- a/src/api/trainee.ts
+++ b/src/api/trainee.ts
@@ -34,6 +34,11 @@ const CreateTraineeApi = (navigate: NavigateFunction) => {
         },
       });
     },
+
+    getDiets: (id: number, page: number, size: number) =>
+      axiosInstance.get(`/diets/${id}`, {
+        params: { page, size },
+      }),
   };
 };
 

--- a/src/api/trainee.ts
+++ b/src/api/trainee.ts
@@ -35,6 +35,8 @@ const CreateTraineeApi = (navigate: NavigateFunction) => {
       });
     },
 
+    deleteDiet: (id: number) => axiosInstance.delete(`/diets/${id}`),
+
     getDiets: (id: number, page: number, size: number) =>
       axiosInstance.get(`/diets/${id}`, {
         params: { page, size },

--- a/src/api/trainee.ts
+++ b/src/api/trainee.ts
@@ -39,6 +39,8 @@ const CreateTraineeApi = (navigate: NavigateFunction) => {
       axiosInstance.get(`/diets/${id}`, {
         params: { page, size },
       }),
+
+    getDietDetail: (id: number) => axiosInstance.get(`/diets/${id}/details`),
   };
 };
 

--- a/src/api/trainee.ts
+++ b/src/api/trainee.ts
@@ -12,6 +12,7 @@ const CreateTraineeApi = (navigate: NavigateFunction) => {
   }
 
   return {
+    // Dashboard
     getTraineeInfo: (id: string | undefined) =>
       axiosInstance.get(`trainers/trainees/${id}`),
 
@@ -20,6 +21,19 @@ const CreateTraineeApi = (navigate: NavigateFunction) => {
 
     addInbodyInfo: (inbodyData: AddInbodyData) =>
       axiosInstance.post('trainers/trainees', inbodyData),
+
+    // Diet
+    addDiet: (image: File, content: string) => {
+      const formData = new FormData();
+      formData.append('image', image);
+      formData.append('content', JSON.stringify(content));
+
+      return axiosInstance.post('/diets/', formData, {
+        headers: {
+          'Content-Type': 'multipart/form-data',
+        },
+      });
+    },
   };
 };
 

--- a/src/api/trainee.ts
+++ b/src/api/trainee.ts
@@ -43,6 +43,9 @@ const CreateTraineeApi = (navigate: NavigateFunction) => {
       }),
 
     getDietDetail: (id: number) => axiosInstance.get(`/diets/${id}/details`),
+
+    addComment: (id: number, comment: string) =>
+      axiosInstance.post('/comments/', { id, comment }),
   };
 };
 

--- a/src/components/Appointment/ScheduleDetail.tsx
+++ b/src/components/Appointment/ScheduleDetail.tsx
@@ -287,7 +287,7 @@ interface ScheduleDetailProps {
 const ScheduleDetail: React.FC<ScheduleDetailProps> = ({ selectedDate }) => {
   const { user } = useUserStore();
   const navigate = useNavigate();
-  const AppointmentApi = CreateAppointmentApi(navigate);
+  const appointmentApi = CreateAppointmentApi(navigate);
   const { openModal, closeModal, isOpen } = useModals();
   const [schedules, setSchedules] = useState<ScheduleType[]>([]);
   const [selectedTime, setSelectedTime] = useState<string | null>(null);
@@ -296,7 +296,7 @@ const ScheduleDetail: React.FC<ScheduleDetailProps> = ({ selectedDate }) => {
 
   const fetchSchedules = async () => {
     const formattedDate = format(selectedDate, 'yyyy-MM-dd');
-    const response = await AppointmentApi.getSchedules(
+    const response = await appointmentApi.getSchedules(
       formattedDate,
       formattedDate
     );
@@ -440,23 +440,23 @@ const ScheduleDetail: React.FC<ScheduleDetailProps> = ({ selectedDate }) => {
     if ($status === 'EMPTY' && selectedTime) {
       const startDate = format(selectedDate, 'yyyy-MM-dd');
       const startTimes = [selectedTime];
-      await AppointmentApi.openSchedules([{ startDate, startTimes }]);
+      await appointmentApi.openSchedules([{ startDate, startTimes }]);
     } else if ($status === 'OPEN' && selectedId) {
-      await AppointmentApi.closeSchedules([selectedId]);
+      await appointmentApi.closeSchedules([selectedId]);
     } else if ($status === 'RESERVE_APPLIED' && selectedId) {
-      await AppointmentApi.acceptSchedule(selectedId);
+      await appointmentApi.acceptSchedule(selectedId);
     } else if ($status === 'RESERVED' && selectedId) {
-      await AppointmentApi.cancelSchedule(selectedId);
+      await appointmentApi.cancelSchedule(selectedId);
     }
   };
 
   const handleTraineeActions = async ($status: ScheduleStatus) => {
     if ($status === 'OPEN' && selectedId) {
-      await AppointmentApi.applySchedule(selectedId);
+      await appointmentApi.applySchedule(selectedId);
     } else if ($status === 'RESERVE_APPLIED' && selectedId) {
-      await AppointmentApi.cancelSchedule(selectedId);
+      await appointmentApi.cancelSchedule(selectedId);
     } else if ($status === 'RESERVED' && selectedId) {
-      await AppointmentApi.cancelSchedule(selectedId);
+      await appointmentApi.cancelSchedule(selectedId);
     }
   };
 
@@ -491,7 +491,7 @@ const ScheduleDetail: React.FC<ScheduleDetailProps> = ({ selectedDate }) => {
       case 'save':
         try {
           if (selectedId) {
-            await AppointmentApi.rejectSchedule(selectedId);
+            await appointmentApi.rejectSchedule(selectedId);
             refetch();
           }
         } catch (error: any) {

--- a/src/components/Appointment/ScheduleDetail.tsx
+++ b/src/components/Appointment/ScheduleDetail.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 import { format } from 'date-fns';
 import { useQuery } from 'react-query';
 
@@ -102,15 +102,15 @@ const ButtonBox = styled.div<{ role?: string }>`
   display: flex;
   justify-content: right;
   gap: 10px;
-  width: 170px;
+  width: ${({ role }) => (role === 'TRAINER' ? '170px' : '80px')};
 
   ${({ role }) =>
     role === 'TRAINER' &&
-    `
-    @media (max-width: 410px) {
-      width: auto;
-    }
-  `}
+    css`
+      @media (max-width: 410px) {
+        width: auto;
+      }
+    `}
 `;
 
 const StatusButton = styled.button<{ $status: ScheduleStatus; role?: string }>`

--- a/src/components/Appointment/TraineeRegisterModal.tsx
+++ b/src/components/Appointment/TraineeRegisterModal.tsx
@@ -82,7 +82,7 @@ const TraineeRegisterModal: React.FC<TraineeRegisterModalProps> = ({
   onClick,
 }) => {
   const navigate = useNavigate();
-  const TrainerApi = CreateTrainerApi(navigate);
+  const trainerApi = CreateTrainerApi(navigate);
   const [items, setItems] = useState<TraineeDataType[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [errorAlert, setErrorAlert] = useState<string>('');
@@ -93,7 +93,7 @@ const TraineeRegisterModal: React.FC<TraineeRegisterModalProps> = ({
         try {
           setIsLoading(true);
 
-          const response = await TrainerApi.getTrainees('NAME', 0, 30);
+          const response = await trainerApi.getTrainees('NAME', 0, 30);
 
           setItems(response.data.content);
         } catch (error) {

--- a/src/components/Appointment/WeeklyCalendar.tsx
+++ b/src/components/Appointment/WeeklyCalendar.tsx
@@ -166,7 +166,7 @@ const WeeklyCalendar: React.FC<WeeklyCalendarProps> = ({
         calendar.removeEventListener('mouseleave', onMouseUp);
       };
     }
-  }, []);
+  }, [selectedDate]);
 
   return (
     <CalendarWrapper ref={calendarRef} onScroll={onInfiniteScroll}>

--- a/src/components/Common/Header/Header.tsx
+++ b/src/components/Common/Header/Header.tsx
@@ -59,7 +59,7 @@ const BackIcon = styled.div`
 const Header: React.FC = () => {
   const location = useLocation();
   const navigate = useNavigate();
-  const AuthApi = CreateAuthApi(navigate);
+  const authApi = CreateAuthApi(navigate);
   const { user, clearUser } = useUserStore();
   const [isDrawerOpen, setDrawerOpen] = useState(false);
 
@@ -77,7 +77,7 @@ const Header: React.FC = () => {
 
   const handleLogout = async () => {
     try {
-      await AuthApi.logout();
+      await authApi.logout();
       clearUser();
     } catch (error) {
       console.error('로그아웃 에러: ', error);

--- a/src/components/Common/Navigation/Navigation.tsx
+++ b/src/components/Common/Navigation/Navigation.tsx
@@ -84,12 +84,12 @@ const LogOutBtn = styled.img``;
 const Navigation: React.FC = () => {
   const location = useLocation();
   const navigate = useNavigate();
-  const AuthApi = CreateAuthApi(navigate);
+  const authApi = CreateAuthApi(navigate);
   const { clearUser } = useUserStore();
 
   const handleLogout = async () => {
     try {
-      await AuthApi.logout();
+      await authApi.logout();
       clearUser();
     } catch (error) {
       console.error('로그아웃 에러: ', error);

--- a/src/components/Trainee/DietUploadModal.tsx
+++ b/src/components/Trainee/DietUploadModal.tsx
@@ -132,6 +132,9 @@ const DietUploadModal: React.FC<DietUploadModalProps> = ({
   const onRemoveImage = () => {
     setFormData({ ...formData, photo: null });
     setPreview(null);
+    if (inputRef.current) {
+      inputRef.current.value = '';
+    }
   };
 
   return (

--- a/src/firebase/notificationPermission.ts
+++ b/src/firebase/notificationPermission.ts
@@ -6,7 +6,7 @@ import { app } from 'src/firebase/initFirebase';
 
 const requestPermission = async (navigate: NavigateFunction) => {
   try {
-    const NotificationApi = CreateNotificationApi(navigate);
+    const notificationApi = CreateNotificationApi(navigate);
 
     const permission = await Notification.requestPermission();
     const messaging = getMessaging(app);
@@ -17,7 +17,7 @@ const requestPermission = async (navigate: NavigateFunction) => {
       });
 
       if (token) {
-        await NotificationApi.registerFCMToken(token);
+        await notificationApi.registerFCMToken(token);
       }
     }
   } catch (error) {

--- a/src/hooks/useFetchSchedules.ts
+++ b/src/hooks/useFetchSchedules.ts
@@ -33,9 +33,9 @@ const fetchSchedules = async (
   startDate: string,
   endDate: string
 ): Promise<ScheduleData> => {
-  const AppointmentApi = CreateAppointmentApi(navigate);
+  const appointmentApi = CreateAppointmentApi(navigate);
 
-  const response = await AppointmentApi.getSchedules(startDate, endDate);
+  const response = await appointmentApi.getSchedules(startDate, endDate);
   const scheduleList: Schedule[] = response?.data;
 
   const scheduled: string[] = [];

--- a/src/hooks/useFetchUser.ts
+++ b/src/hooks/useFetchUser.ts
@@ -6,13 +6,13 @@ import CreateAuthApi from 'src/api/auth';
 
 const useFetchUser = () => {
   const navigate = useNavigate();
-  const AuthApi = CreateAuthApi(navigate);
+  const authApi = CreateAuthApi(navigate);
   const { setUser, clearUser } = useUserStore();
 
   useEffect(() => {
     const fetchUser = async () => {
       try {
-        const response = await AuthApi.getUser();
+        const response = await authApi.getUser();
         const userData = response.data;
         const user: User = {
           id: userData.id,

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -9,6 +9,9 @@ const queryClient = new QueryClient();
 
 // enableMocking 함수 정의
 async function enableMocking() {
+  // 모든환경에서 MSW 사용안함 (필요시 return 삭제)
+  return;
+
   if (process.env.NODE_ENV !== 'development') {
     return;
   }

--- a/src/pages/Appointment/MonthlyContent.tsx
+++ b/src/pages/Appointment/MonthlyContent.tsx
@@ -60,7 +60,7 @@ const MonthlyContent: React.FC = () => {
   const { setSelectedDate, startDate, endDate } = useCalendarStore();
   const { data, isLoading, refetch } = useFetchSchedules(startDate, endDate);
   const { openModal, closeModal, isOpen } = useModals();
-  const AppointmentApi = CreateAppointmentApi(navigate);
+  const appointmentApi = CreateAppointmentApi(navigate);
   const [selectedButton, setSelectedButton] = useState<string | null>(null);
   const [selectedDates, setSelectedDates] = useState<string[]>([]);
   const [selectedTimes, setSelectedTimes] = useState<string[]>([]);
@@ -144,7 +144,7 @@ const MonthlyContent: React.FC = () => {
           [] as { startDate: string; startTimes: string[] }[]
         );
 
-        await AppointmentApi.openSchedules(dateTimes);
+        await appointmentApi.openSchedules(dateTimes);
         refetch({ force: true });
       } catch (error) {
         console.error('수업 일괄 오픈 에러: ', error);
@@ -164,7 +164,7 @@ const MonthlyContent: React.FC = () => {
           [] as { startDate: string; startTimes: string[] }[]
         );
 
-        await AppointmentApi.registerSchedules({
+        await appointmentApi.registerSchedules({
           traineeId: selectedTraineeId,
           dateTimes: dateTimes,
         });

--- a/src/pages/Appointment/MonthlyContent.tsx
+++ b/src/pages/Appointment/MonthlyContent.tsx
@@ -57,7 +57,7 @@ const MonthlyContent: React.FC = () => {
   useFetchUser();
   const navigate = useNavigate();
   const { user } = useUserStore();
-  const { startDate, endDate } = useCalendarStore();
+  const { setSelectedDate, startDate, endDate } = useCalendarStore();
   const { data, isLoading, refetch } = useFetchSchedules(startDate, endDate);
   const { openModal, closeModal, isOpen } = useModals();
   const AppointmentApi = CreateAppointmentApi(navigate);
@@ -84,6 +84,7 @@ const MonthlyContent: React.FC = () => {
   };
 
   const onDateClick = (date: Date) => {
+    setSelectedDate(date);
     const formattedDate = format(date, 'yyyy-MM-dd');
 
     if (!selectedButton) {

--- a/src/pages/Appointment/WeeklyContent.tsx
+++ b/src/pages/Appointment/WeeklyContent.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import styled from 'styled-components';
 import { format, parse } from 'date-fns';
@@ -17,12 +17,10 @@ const Wrapper = styled.div`
 const WeeklyContent: React.FC = () => {
   const { date } = useParams<{ date: string }>();
   const navigate = useNavigate();
-  const { setSelectedDate } = useCalendarStore();
-  const initialDate = date ? parse(date, 'yyyy-MM-dd', new Date()) : new Date();
-  const [currentDate, setCurrentDate] = useState<Date>(initialDate);
+  const { selectedDate, setSelectedDate } = useCalendarStore();
 
   const onDateChange = (date: Date) => {
-    setCurrentDate(date);
+    setSelectedDate(date);
 
     const formattedDate = format(date, 'yyyy-MM-dd');
     navigate(`/appointment/weekly/${formattedDate}`, { replace: true });
@@ -39,10 +37,10 @@ const WeeklyContent: React.FC = () => {
     <SectionWrapper>
       <Wrapper>
         <WeeklyCalendar
-          selectedDate={currentDate}
+          selectedDate={selectedDate}
           onDateChange={onDateChange}
         />
-        <ScheduleDetail selectedDate={currentDate} />
+        <ScheduleDetail selectedDate={selectedDate} />
       </Wrapper>
     </SectionWrapper>
   );

--- a/src/pages/Appointment/WeeklyContent.tsx
+++ b/src/pages/Appointment/WeeklyContent.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import styled from 'styled-components';
 import { format, parse } from 'date-fns';
@@ -22,12 +22,18 @@ const WeeklyContent: React.FC = () => {
   const [currentDate, setCurrentDate] = useState<Date>(initialDate);
 
   const onDateChange = (date: Date) => {
-    setSelectedDate(date);
     setCurrentDate(date);
 
     const formattedDate = format(date, 'yyyy-MM-dd');
     navigate(`/appointment/weekly/${formattedDate}`, { replace: true });
   };
+
+  useEffect(() => {
+    if (!date) return;
+
+    const parsedDate = parse(date, 'yyyy-MM-dd', new Date());
+    setSelectedDate(parsedDate);
+  }, []);
 
   return (
     <SectionWrapper>

--- a/src/pages/Appointment/WeeklyContent.tsx
+++ b/src/pages/Appointment/WeeklyContent.tsx
@@ -7,6 +7,7 @@ import WeeklyCalendar from '@components/Appointment/WeeklyCalendar';
 import ScheduleDetail from '@components/Appointment/ScheduleDetail';
 import { SectionWrapper } from '@components/Common/SectionWrapper';
 import useCalendarStore from 'src/stores/calendarStore';
+import useFetchUser from 'src/hooks/useFetchUser';
 
 const Wrapper = styled.div`
   display: flex;
@@ -15,6 +16,7 @@ const Wrapper = styled.div`
 `;
 
 const WeeklyContent: React.FC = () => {
+  useFetchUser();
   const { date } = useParams<{ date: string }>();
   const navigate = useNavigate();
   const { selectedDate, setSelectedDate } = useCalendarStore();

--- a/src/pages/Login/Login.tsx
+++ b/src/pages/Login/Login.tsx
@@ -23,7 +23,7 @@ interface FormState {
 
 const Login: React.FC = () => {
   const navigate = useNavigate();
-  const AuthApi = CreateAuthApi(navigate);
+  const authApi = CreateAuthApi(navigate);
   const { setUser } = useUserStore();
 
   const [isLoading, setLoading] = useState<boolean>(false);
@@ -66,7 +66,7 @@ const Login: React.FC = () => {
     try {
       setLoading(true);
 
-      const response = await AuthApi.login(email, password);
+      const response = await authApi.login(email, password);
       const user = {
         id: response.data.id,
         role: response.data.role,

--- a/src/pages/Signup/Signup.tsx
+++ b/src/pages/Signup/Signup.tsx
@@ -31,7 +31,7 @@ interface FormState {
 
 const Signup: React.FC = () => {
   const navigate = useNavigate();
-  const AuthApi = CreateAuthApi(navigate);
+  const authApi = CreateAuthApi(navigate);
   const { setUser } = useUserStore();
 
   const {
@@ -64,7 +64,7 @@ const Signup: React.FC = () => {
     try {
       setLoading(true);
 
-      const response = await AuthApi.signup(
+      const response = await authApi.signup(
         data.email,
         data.password,
         data.confirmPassword,
@@ -92,7 +92,7 @@ const Signup: React.FC = () => {
     try {
       setSendingEmail(true);
 
-      await AuthApi.checkEmail(email);
+      await authApi.checkEmail(email);
 
       setShowEmailCodeInput(true);
 
@@ -122,7 +122,7 @@ const Signup: React.FC = () => {
     }
 
     try {
-      await AuthApi.checkCode(email, verificationCode);
+      await authApi.checkCode(email, verificationCode);
       setIsCodeVerified(true);
       setSuccessAlert('이메일 인증에 성공했습니다.');
     } catch (error: any) {

--- a/src/pages/Trainee/Diet.tsx
+++ b/src/pages/Trainee/Diet.tsx
@@ -71,7 +71,7 @@ const Diet: React.FC = () => {
     const response = await traineeApi.getDiets(
       parseInt(traineeId!),
       pageParam,
-      3
+      9
     );
     return response.data;
   };
@@ -131,17 +131,36 @@ const Diet: React.FC = () => {
 
   return (
     <Wrapper>
-      <Gallery>
-        {diets.map((diet, index) => (
-          <ImageWrapper
-            key={diet.dietId}
-            onClick={() => onClickDiet(diet.dietId)}
-            ref={diets.length === index + 1 ? loadMoreRef : null}
-          >
-            <Image src={diet.thumbnailUrl} alt={`diet image`} loading="lazy" />
-          </ImageWrapper>
-        ))}
-      </Gallery>
+      {diets.length === 0 ? (
+        <div
+          style={{
+            fontSize: '1.4rem',
+            display: 'flex',
+            justifyContent: 'center',
+            height: '50vh',
+            alignItems: 'center',
+          }}
+        >
+          식단이 없습니다.
+        </div>
+      ) : (
+        <Gallery>
+          {diets.map((diet, index) => (
+            <ImageWrapper
+              key={diet.dietId}
+              onClick={() => onClickDiet(diet.dietId)}
+              ref={diets.length === index + 1 ? loadMoreRef : null}
+            >
+              <Image
+                src={diet.thumbnailUrl}
+                alt={`diet image`}
+                loading="lazy"
+              />
+            </ImageWrapper>
+          ))}
+        </Gallery>
+      )}
+
       {user?.role === 'TRAINEE' && (
         <React.Fragment>
           <AddButton onClick={onClickAddButton}>

--- a/src/pages/Trainee/Diet.tsx
+++ b/src/pages/Trainee/Diet.tsx
@@ -1,7 +1,7 @@
-import React, { useEffect, useState } from 'react';
+import React, { useRef, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import styled from 'styled-components';
-import InfiniteScroll from 'react-infinite-scroll-component';
+import { useInfiniteQuery } from 'react-query';
 
 import addBtn from '@icons/home/addbtn.svg';
 import { AddButton } from '@components/Common/AddButton';
@@ -14,7 +14,7 @@ import CreateTraineeApi from 'src/api/trainee';
 import useUserStore from 'src/stores/userStore';
 
 const Wrapper = styled.div`
-  height: calc(100vh - 150px);
+  height: calc(100dvh - 150px);
   overflow: auto;
 `;
 
@@ -37,17 +37,19 @@ const Image = styled.img`
   object-fit: cover;
 `;
 
-// pixabay에서 제공하는 150px 크기의 무료 이미지 링크 (추후 API 연동시 삭제)
-const getMoreImages = (count = 9) => {
-  const images = [];
-  for (let i = 0; i < count; i++) {
-    images.push(
-      `https://via.placeholder.com/150?text=Image${Math.floor(Math.random() * 100)}`
-    );
-  }
+interface Diet {
+  dietId: number;
+  thumbnailUrl: string;
+}
 
-  return images;
-};
+interface DietResponse {
+  content: Diet[];
+  pageable: {
+    pageNumber: number;
+  };
+  totalPages: number;
+  last: boolean;
+}
 
 const Diet: React.FC = () => {
   useFetchUser();
@@ -56,21 +58,40 @@ const Diet: React.FC = () => {
   const traineeApi = CreateTraineeApi(navigate);
   const { traineeId } = useParams<{ traineeId: string }>();
   const { openModal, closeModal, isOpen } = useModals();
-  const [images, setImages] = useState<string[]>([]);
+  const observerRef = useRef<IntersectionObserver | null>(null);
   const [formData, setFormData] = useState<{
     photo: FileList | null;
     content: string;
   }>({ photo: null, content: '' });
   const [preview, setPreview] = useState<string | null>(null);
-  const [isLoading, setLoading] = useState<boolean>(false);
+  const [isUploading, setIsUploading] = useState<boolean>(false);
   const [errorAlert, setErrorAlert] = useState<string>('');
 
-  const fetchMoreImages = async () => {
-    if (isLoading) return;
-    setLoading(true);
+  const fetchDiets = async ({ pageParam = 0 }): Promise<DietResponse> => {
+    const response = await traineeApi.getDiets(
+      parseInt(traineeId!),
+      pageParam,
+      3
+    );
+    return response.data;
+  };
 
-    setImages(prevImages => [...prevImages, ...getMoreImages()]);
-    setLoading(false);
+  const { data, fetchNextPage, hasNextPage, refetch } =
+    useInfiniteQuery<DietResponse>('diets', fetchDiets, {
+      getNextPageParam: lastPage =>
+        lastPage.last ? null : lastPage.pageable.pageNumber + 1,
+    });
+
+  const diets = data?.pages.flatMap(page => page.content) || [];
+
+  const loadMoreRef = (node: HTMLElement | null) => {
+    if (observerRef.current) observerRef.current.disconnect();
+    observerRef.current = new IntersectionObserver(entries => {
+      if (entries[0].isIntersecting && hasNextPage) {
+        fetchNextPage();
+      }
+    });
+    if (node) observerRef.current.observe(node);
   };
 
   const onClickDiet = (dietId: number) => {
@@ -95,34 +116,32 @@ const Diet: React.FC = () => {
     const photo = formData.photo[0];
 
     try {
+      setIsUploading(true);
       await traineeApi.addDiet(photo, formData.content);
+      refetch();
       closeModal('addModal');
     } catch (error) {
       console.error('식단 추가 에러: ', error);
+    } finally {
+      setIsUploading(false);
     }
   };
 
   const onCloseErrorAlert = () => setErrorAlert('');
 
-  useEffect(() => setImages(getMoreImages(24)), []);
-
   return (
-    <Wrapper id="scrollDiv">
-      <InfiniteScroll
-        dataLength={images.length}
-        next={fetchMoreImages}
-        hasMore={true}
-        loader={<h4>Loading...</h4>}
-        scrollableTarget="scrollDiv"
-      >
-        <Gallery>
-          {images.map((src, index) => (
-            <ImageWrapper key={index} onClick={() => onClickDiet(index)}>
-              <Image src={src} alt={`image ${index}`} loading="lazy" />
-            </ImageWrapper>
-          ))}
-        </Gallery>
-      </InfiniteScroll>
+    <Wrapper>
+      <Gallery>
+        {diets.map((diet, index) => (
+          <ImageWrapper
+            key={diet.dietId}
+            onClick={() => onClickDiet(diet.dietId)}
+            ref={diets.length === index + 1 ? loadMoreRef : null}
+          >
+            <Image src={diet.thumbnailUrl} alt={`diet image`} loading="lazy" />
+          </ImageWrapper>
+        ))}
+      </Gallery>
       {user?.role === 'TRAINEE' && (
         <React.Fragment>
           <AddButton onClick={onClickAddButton}>
@@ -134,7 +153,7 @@ const Diet: React.FC = () => {
             isOpen={isOpen('addModal')}
             onClose={() => closeModal('addModal')}
             onSave={() => onSaveAddModal()}
-            btnConfirm="등록"
+            btnConfirm={isUploading ? '등록 중...' : '등록'}
           >
             <DietUploadModal
               formData={formData}

--- a/src/pages/Trainee/DietDetail.tsx
+++ b/src/pages/Trainee/DietDetail.tsx
@@ -63,6 +63,7 @@ const Contents = styled.p`
   flex: 1;
   font-size: 1.4rem;
   color: ${({ theme }) => theme.colors.gray900};
+  white-space: pre-line;
 `;
 
 const DotButton = styled.div`
@@ -345,11 +346,12 @@ const DietDetail: React.FC = () => {
         <ContentsContainer>
           <PostDate>{formatDate(dietDetail!.createdDate)}</PostDate>
           <ContentsBox>
-            <Contents
+            {/* <Contents
               dangerouslySetInnerHTML={{
                 __html: dietDetail!.content.replace(/\n/g, '<br />'),
               }}
-            />
+            /> */}
+            <Contents>{dietDetail!.content}</Contents>
             {user?.role === 'TRAINEE' && (
               <DotButton onClick={togglePostMenu}>
                 <img src={threeDots} alt="Button group: Delete options" />

--- a/src/pages/Trainee/DietDetail.tsx
+++ b/src/pages/Trainee/DietDetail.tsx
@@ -264,10 +264,14 @@ const DietDetail: React.FC = () => {
     setCommentMenuVisible(!commentMenuVisible);
   };
 
-  const onSaveModal = (modalName: string) => {
+  const onSaveModal = async (modalName: string) => {
     if (modalName === 'deletePostModal') {
-      // 식단 삭제 API 요청 단계 추가
-      navigate(`/trainee/${traineeId}/diet`);
+      try {
+        await traineeApi.deleteDiet(parseInt(dietId!));
+        navigate(`/trainee/${traineeId}/diet`);
+      } catch (error) {
+        console.error('식단 삭제 에러: ', error);
+      }
     } else if (modalName === 'deleteCommentModal') {
       // 댓글 삭제 API 요청 단계 추가 (refetch)
     }

--- a/src/routes/ProtectedRoute.tsx
+++ b/src/routes/ProtectedRoute.tsx
@@ -1,14 +1,19 @@
 import React from 'react';
-import { Navigate, Outlet, useLocation } from 'react-router-dom';
+import { Navigate, Outlet, useLocation, useParams } from 'react-router-dom';
 
 import useUserStore from 'src/stores/userStore';
 
 const ProtectedRoute: React.FC = () => {
   const location = useLocation();
   const { user } = useUserStore();
+  const { traineeId } = useParams<{ traineeId: string }>();
 
   if (!user) {
     return <Navigate to="/login" state={{ from: location }} />;
+  }
+
+  if (traineeId && isNaN(Number(traineeId))) {
+    return <Navigate to="/not-found" replace />;
   }
 
   return <Outlet />;

--- a/src/styles/globalStyles.ts
+++ b/src/styles/globalStyles.ts
@@ -12,13 +12,13 @@ ${reset};
 
 
 
-//font-size base = 10px = 1rem / ex) 16px === 1.6rem 
+//font-size base = 10px = 1rem / ex) 16px === 1.6rem
 html, body{
   font-size: 10px;
   line-height: 1.5;
   font-family: 'NanumSquare', 'Noto Sans KR', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
 
-  height: 100vh;
+  height: 100dvh;
   background-color: ${({ theme }) => theme.colors.gray200};
 }
 


### PR DESCRIPTION
### 📝 관련 이슈
closed #64 

### ✨ 반영 브랜치
- FROM: `64-feat/trainee-diet-api`
- TO: `master`

### ✅ PR 내용

### ALL
- [x] 식단 목록 조회 API 연동
- [x] 무한스크롤 방식 변경 (`react-infinite-scroll-component` -> `IntersectionObserver`)
> - 식단관리 탭에 들어가면 트레이니가 올린 식단 사진 목록을 무한스크롤로 모아볼 수 있음
> - 사진 용량을 최적화하여 렌더링 속도를 올리기 위해 `lazy-loading`과 썸네일크기(150 * 150px)의 이미지 파일 사용
> - 기존에 사용했던 `react-infinite-scroll-component` 라이브러리를 통한 무한스크롤 방식에서 `React` 내장된 기능인 `IntersectionObserver`로 변경. 페이지당 9개씩 데이터를 요청하고 마지막 요소를 `IntersectionObserver`의 관찰 node로 두었다가 뷰포트와 교차되는 시점에 `react-query`의 `useInfiniteQuery`를 이용해서 다음 페이지 이미지들을 받아옴
> - `package.json`과 `package.lock.json`에서 `react-infinite-scroll-component` 패키지 삭제 
> - 무한스크롤 방식 변경 이유는 `react-infinite-scroll-component`이 빠르고 간단하게 무한스크롤을 적용할 수 있다는 장점이 있지만, 스크롤하는 영역을 인식하는 데 버그가 있었고, `img` 태그에 `loading` 속성을 줘서 `lazy-loading`을 적용해도 뷰포트를 한참 벗어나있는 데이터까지 한번에 받아와서 렌더링 속도가 늦었음. 그리고 트다 서비스 내 가로와 세로 무한스크롤을 적용한 곳이 많은데 일관성을 위해 `IntersectionObserver`로 통일

- [x] 식단 상세 조회 API 연동
> - 식단관리 탭의 식단 목록에서 특정 식단을 클릭하면 식단 상세 페이지로 이동
> - 식단 목록에서는 썸네일크기(`150 * 150px`)의 이미지 파일을 사용했지만 상세 페이지에서는 최대 뷰포트 너비에 맞춰 `410 * 410 px`의 이미지 파일을 렌더링
> - 식단 추가와 삭제는 트레이니 권한, 식단에 대한 댓글 추가/수정/삭제는 트레이너 권한으로 한정

### TRAINEE
- [x] 식단 생성 API 연동
- [x] 식단 삭제 API 연동
> - 식단 추가 시 이미지 1장 업로드와 `contents`를 입력받고 서버에서 이미지 리사이징 후 2가지 크기의 `url`로 저장
> - 식단 `contents`는 `textarea` 태그를 사용하여 입력시 개행이 가능하도록 했고 조회해서 보여줄 때도 `white-space: pre-line` CSS를 적용하여 개행 처리
> - 식단 생성과 식단 삭제 모두 API 요청 후 `refetch`를 통해 식단 관리 탭 목록을 다시 불러옴

### TRAINER
- [x] 댓글 추가 API 연동
- [x] 댓글 수정 API 연동
- [x] 댓글 삭제 API 연동
> - 트레이너는 본인과 연동된 트레이니의 식단 상세페이지에서 댓글을 추가, 수정, 삭제 가능
> - 댓글 관련 API 요청 후 `refetch`를 통해 식단 상세 페이지를 다시 불러옴

### BUG FIX
- [x] 주별 시간표에서 특정 날짜 클릭시 월별 시간표 탭 눌러서 이동하면 해당 월 동기화
- [x] 월별 시간표에서 특정 날짜를 클릭해 주별 시간표로 넘어갔을 때 해당 날짜를 기준으로 캘린더 영역이 나오지 않는 에러 수정
- [x] 모바일 화면에서 세로스크롤 아래 위로 움직일 때 화면의 끝까지 한번에 이동되지 않는 에러 수정
> - 기기별 `vh` 기준이 다르므로 `dvh` 값을 사용하여 유연하게 적용


### 🌐 테스트 배포
- [x] 테스트 배포하여 잘 동작하는 지 확인했나요?
> - 테스트 배포 주소: https://sm.training-diary.co.kr
> - 테스트 환경 (Desktop): MacOS (Chrome / Safari / Firefox / Edge)
> - 테스트 환경 (Mobile): Android (Chrome / 삼성인터넷)

### 📌 ETC
- 무한스크롤 방식을 바꾸면서 `react-infinite-scroll-component` 라이브러리 삭제했습니다. `npm ci` 해주세요!
